### PR TITLE
feat: add team and member_role resources

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        id: import_gpg
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/docs/data-sources/member.md
+++ b/docs/data-sources/member.md
@@ -1,0 +1,35 @@
+---
+title: "growthbook_member Data Source"
+description: |-
+  Look up a GrowthBook organization member by email.
+---
+
+# growthbook_member
+
+Use this data source to look up a GrowthBook organization member by email.
+
+## Example Usage
+
+```hcl
+data "growthbook_member" "joao" {
+  email = "joao@example.com"
+}
+```
+
+## Argument Reference
+
+- `email` (String, Required) – The email of the member to look up.
+
+## Attributes Reference
+
+- `id` (String) – The unique member ID.
+- `name` (String) – The member's display name.
+- `role` (String) – The member's global role.
+- `limit_access_by_environment` (Boolean) – Whether access is restricted by environment.
+- `environments` (List of String) – Environments the member has access to.
+- `project_roles` (List of Object) – Per-project role assignments.
+- `teams` (List of String) – Team IDs the member belongs to.
+- `managed_by_idp` (Boolean) – Whether managed by an identity provider.
+- `last_login_date` (String) – The member's last login date.
+- `date_created` (String) – The creation date.
+- `date_updated` (String) – The last update date.

--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -1,0 +1,35 @@
+---
+title: "growthbook_team Data Source"
+description: |-
+  Look up a GrowthBook team by name.
+---
+
+# growthbook_team
+
+Use this data source to look up a GrowthBook team by name.
+
+## Example Usage
+
+```hcl
+data "growthbook_team" "engineering" {
+  name = "Engineering"
+}
+```
+
+## Argument Reference
+
+- `name` (String, Required) – The name of the team to look up.
+
+## Attributes Reference
+
+- `id` (String) – The unique ID of the team.
+- `description` (String) – The team description.
+- `role` (String) – The global role for team members.
+- `limit_access_by_environment` (Boolean) – Whether access is restricted by environment.
+- `environments` (List of String) – Environments the team has access to.
+- `project_roles` (List of Object) – Per-project role assignments.
+- `members` (List of String) – Member IDs in this team.
+- `managed_by_idp` (Boolean) – Whether the team is managed by an identity provider.
+- `created_by` (String) – The user who created the team.
+- `date_created` (String) – The creation date.
+- `date_updated` (String) – The last update date.

--- a/docs/resources/member_role.md
+++ b/docs/resources/member_role.md
@@ -1,0 +1,62 @@
+---
+title: "growthbook_member_role Resource"
+description: |-
+  Manages the role and permissions of an existing GrowthBook organization member.
+---
+
+# growthbook_member_role
+
+Manages the role and permissions of an existing GrowthBook organization member.
+
+~> **Note:** This resource does not create or invite members. Members must already exist in the organization (invited via the GrowthBook UI). This resource adopts an existing member by email and manages their role configuration.
+
+~> **Warning:** Destroying this resource will **remove the member from the organization**.
+
+## Example Usage
+
+```hcl
+resource "growthbook_member_role" "joao" {
+  email = "joao@example.com"
+  role  = "engineer"
+
+  limit_access_by_environment = true
+  environments                = ["production", "staging"]
+
+  project_roles {
+    project                     = "prj_main"
+    role                        = "admin"
+    limit_access_by_environment = false
+    environments                = []
+  }
+}
+```
+
+## Argument Reference
+
+- `email` (String, Required, ForceNew) – The member's email address. Used to look up the existing member.
+- `role` (String, Required) – The member's global role (e.g. `readonly`, `collaborator`, `engineer`, `analyst`, `experimenter`, `admin`).
+- `limit_access_by_environment` (Boolean, Optional) – Whether to restrict access to specific environments. Defaults to `false`.
+- `environments` (List of String, Optional) – Environments the member has access to. Empty means all.
+- `project_roles` (List of Object, Optional) – Per-project role overrides. Each object supports:
+  - `project` (String, Required) – The project ID.
+  - `role` (String, Required) – The role for this project.
+  - `limit_access_by_environment` (Boolean, Optional) – Defaults to `false`.
+  - `environments` (List of String, Optional) – Environments for this project role.
+
+## Attributes Reference
+
+- `id` (String) – The unique member ID.
+- `name` (String) – The member's display name.
+- `teams` (List of String) – Team IDs the member belongs to.
+- `managed_by_idp` (Boolean) – Whether the member is managed by an identity provider.
+- `last_login_date` (String) – The member's last login date.
+- `date_created` (String) – The creation date.
+- `date_updated` (String) – The last update date.
+
+## Import
+
+Member roles can be imported using the member ID:
+
+```sh
+terraform import growthbook_member_role.example <member_id>
+```

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -1,0 +1,61 @@
+---
+title: "growthbook_team Resource"
+description: |-
+  Provides a GrowthBook Team resource.
+---
+
+# growthbook_team
+
+Manages a GrowthBook team. Teams allow you to assign roles and permissions to groups of members.
+
+## Example Usage
+
+```hcl
+resource "growthbook_team" "engineering" {
+  name        = "Engineering"
+  description = "Backend engineering team"
+  role        = "engineer"
+
+  environments = ["production", "staging"]
+  limit_access_by_environment = true
+
+  members = ["user_abc123", "user_def456"]
+
+  project_roles {
+    project                     = "prj_main"
+    role                        = "admin"
+    limit_access_by_environment = false
+    environments                = []
+  }
+}
+```
+
+## Argument Reference
+
+- `name` (String, Required) – The team name.
+- `description` (String, Optional) – The team description.
+- `role` (String, Required) – The global role for team members (e.g. `readonly`, `collaborator`, `engineer`, `analyst`, `experimenter`, `admin`).
+- `limit_access_by_environment` (Boolean, Optional) – Whether to restrict access to specific environments. Defaults to `false`.
+- `environments` (List of String, Optional) – Environments the team has access to. Empty means all.
+- `members` (Set of String, Optional) – Member IDs in this team.
+- `project_roles` (List of Object, Optional) – Per-project role overrides. Each object supports:
+  - `project` (String, Required) – The project ID.
+  - `role` (String, Required) – The role for this project.
+  - `limit_access_by_environment` (Boolean, Optional) – Defaults to `false`.
+  - `environments` (List of String, Optional) – Environments for this project role.
+
+## Attributes Reference
+
+- `id` (String) – The unique ID of the team.
+- `managed_by_idp` (Boolean) – Whether the team is managed by an identity provider.
+- `created_by` (String) – The user who created the team.
+- `date_created` (String) – The creation date.
+- `date_updated` (String) – The last update date.
+
+## Import
+
+Teams can be imported using the team ID:
+
+```sh
+terraform import growthbook_team.example <team_id>
+```

--- a/internal/data_source_member.go
+++ b/internal/data_source_member.go
@@ -1,0 +1,118 @@
+package internal
+
+import (
+	"context"
+	"terraform-provider-growthbook/internal/growthbookapi"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceMember() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceMemberRead,
+		Schema: map[string]*schema.Schema{
+			"email": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The email of the GrowthBook member.",
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"role": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The member's global role.",
+			},
+			"limit_access_by_environment": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"environments": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"project_roles": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"project": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"role": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"limit_access_by_environment": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"environments": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"teams": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"managed_by_idp": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"last_login_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"date_created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"date_updated": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceMemberRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*growthbookapi.Client)
+	email := d.Get("email").(string)
+	member, err := client.FindMemberByEmail(ctx, email)
+	if err != nil {
+		return diag.Diagnostics{
+			diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Unable to find GrowthBook member by email",
+				Detail:   err.Error(),
+			},
+		}
+	}
+	d.SetId(member.ID)
+	d.Set("email", member.Email)
+	d.Set("name", member.Name)
+	d.Set("role", member.Role)
+	d.Set("limit_access_by_environment", member.LimitAccessByEnvironment)
+	d.Set("environments", member.Environments)
+	d.Set("project_roles", flattenProjectRoles(member.ProjectRoles))
+	d.Set("teams", member.Teams)
+	d.Set("managed_by_idp", member.ManagedByIdp)
+	d.Set("last_login_date", member.LastLoginDate)
+	d.Set("date_created", member.DateCreated)
+	d.Set("date_updated", member.DateUpdated)
+	return nil
+}

--- a/internal/data_source_team.go
+++ b/internal/data_source_team.go
@@ -1,0 +1,118 @@
+package internal
+
+import (
+	"context"
+	"terraform-provider-growthbook/internal/growthbookapi"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceTeam() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTeamRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the GrowthBook team.",
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"role": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The global role for team members.",
+			},
+			"limit_access_by_environment": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"environments": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"project_roles": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"project": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"role": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"limit_access_by_environment": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"environments": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"members": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"managed_by_idp": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"created_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"date_created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"date_updated": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*growthbookapi.Client)
+	name := d.Get("name").(string)
+	team, err := client.FindTeamByName(ctx, name)
+	if err != nil {
+		return diag.Diagnostics{
+			diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Unable to find GrowthBook team by name",
+				Detail:   err.Error(),
+			},
+		}
+	}
+	d.SetId(team.ID)
+	d.Set("name", team.Name)
+	d.Set("description", team.Description)
+	d.Set("role", team.Role)
+	d.Set("limit_access_by_environment", team.LimitAccessByEnvironment)
+	d.Set("environments", team.Environments)
+	d.Set("project_roles", flattenProjectRoles(team.ProjectRoles))
+	d.Set("members", team.Members)
+	d.Set("managed_by_idp", team.ManagedByIdp)
+	d.Set("created_by", team.CreatedBy)
+	d.Set("date_created", team.DateCreated)
+	d.Set("date_updated", team.DateUpdated)
+	return nil
+}

--- a/internal/growthbookapi/client.go
+++ b/internal/growthbookapi/client.go
@@ -61,6 +61,26 @@ type ClientAPI interface {
 	UpdateAttribute(ctx context.Context, property string, a *Attribute) (*Attribute, error)
 	// DeleteAttribute deletes an attribute by its property
 	DeleteAttribute(ctx context.Context, property string) error
+	// CreateTeam creates a new team.
+	CreateTeam(ctx context.Context, t *Team) (*Team, error)
+	// GetTeam retrieves a team by its ID.
+	GetTeam(ctx context.Context, id string) (*Team, error)
+	// UpdateTeam updates an existing team by its ID.
+	UpdateTeam(ctx context.Context, id string, t *Team) (*Team, error)
+	// DeleteTeam deletes a team by its ID.
+	DeleteTeam(ctx context.Context, id string) error
+	// FindTeamByName retrieves a team by its name.
+	FindTeamByName(ctx context.Context, name string) (*Team, error)
+	// ListMembers retrieves all organization members.
+	ListMembers(ctx context.Context) ([]Member, error)
+	// GetMember retrieves a member by its ID.
+	GetMember(ctx context.Context, id string) (*Member, error)
+	// FindMemberByEmail retrieves a member by email.
+	FindMemberByEmail(ctx context.Context, email string) (*Member, error)
+	// UpdateMemberRole updates a member's role and permissions.
+	UpdateMemberRole(ctx context.Context, id string, update *MemberRoleUpdate) (*Member, error)
+	// DeleteMember removes a member from the organization.
+	DeleteMember(ctx context.Context, id string) error
 }
 
 // BackoffConfig defines the configuration for retrying transient errors.

--- a/internal/growthbookapi/member.go
+++ b/internal/growthbookapi/member.go
@@ -1,0 +1,52 @@
+package growthbookapi
+
+import (
+	"context"
+)
+
+// ListMembers fetches all organization members with pagination.
+func (c *Client) ListMembers(ctx context.Context) ([]Member, error) {
+	return fetcher[Member](c, "GET", "/members").All(ctx, nil, "members")
+}
+
+// GetMember fetches a member by ID (lists all and filters).
+func (c *Client) GetMember(ctx context.Context, id string) (*Member, error) {
+	members, err := c.ListMembers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, m := range members {
+		if m.ID == id {
+			return &m, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+// FindMemberByEmail searches for a member by email.
+func (c *Client) FindMemberByEmail(ctx context.Context, email string) (*Member, error) {
+	members, err := c.ListMembers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, m := range members {
+		if m.Email == email {
+			return &m, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+// UpdateMemberRole updates a member's global role, environments, and project roles.
+func (c *Client) UpdateMemberRole(ctx context.Context, id string, update *MemberRoleUpdate) (*Member, error) {
+	out, err := fetcher[Member](c, "POST", "/members/"+id+"/role").One(ctx, update, "member")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// DeleteMember removes a member from the organization.
+func (c *Client) DeleteMember(ctx context.Context, id string) error {
+	return c.delete(ctx, "/members/"+id)
+}

--- a/internal/growthbookapi/models.go
+++ b/internal/growthbookapi/models.go
@@ -87,6 +87,59 @@ type Attribute struct {
 	Description	string	  `json:"description"`
 }
 
+// Member represents a GrowthBook organization member.
+type Member struct {
+	ID                       string        `json:"id,omitempty"`
+	Name                     string        `json:"name,omitempty"`
+	Email                    string        `json:"email,omitempty"`
+	Role                     string        `json:"role,omitempty"`
+	LimitAccessByEnvironment bool          `json:"limitAccessByEnvironment"`
+	Environments             []string      `json:"environments"`
+	ProjectRoles             []ProjectRole `json:"projectRoles"`
+	Teams                    []string      `json:"teams,omitempty"`
+	ManagedByIdp             bool          `json:"managedByIdp,omitempty"`
+	LastLoginDate            string        `json:"lastLoginDate,omitempty"`
+	DateCreated              string        `json:"dateCreated,omitempty"`
+	DateUpdated              string        `json:"dateUpdated,omitempty"`
+}
+
+// MemberRoleUpdate represents the payload for POST /members/{id}/role.
+type MemberRoleUpdate struct {
+	Role                     string        `json:"role"`
+	Environments             []string      `json:"environments"`
+	LimitAccessByEnvironment bool          `json:"limitAccessByEnvironment"`
+	ProjectRoles             []ProjectRole `json:"projectRoles"`
+}
+
+// ProjectRole represents a per-project role assignment.
+type ProjectRole struct {
+	Project                  string   `json:"project"`
+	Role                     string   `json:"role"`
+	LimitAccessByEnvironment bool     `json:"limitAccessByEnvironment"`
+	Environments             []string `json:"environments"`
+}
+
+// Team represents a GrowthBook team.
+type Team struct {
+	ID                       string        `json:"id,omitempty"`
+	Name                     string        `json:"name"`
+	Description              string        `json:"description"`
+	Role                     string        `json:"role"`
+	LimitAccessByEnvironment bool          `json:"limitAccessByEnvironment"`
+	Environments             []string      `json:"environments"`
+	ProjectRoles             []ProjectRole `json:"projectRoles"`
+	Members                  []string      `json:"members"`
+	ManagedByIdp             bool          `json:"managedByIdp,omitempty"`
+	CreatedBy                string        `json:"createdBy,omitempty"`
+	DateCreated              string        `json:"dateCreated,omitempty"`
+	DateUpdated              string        `json:"dateUpdated,omitempty"`
+}
+
+// TeamMemberUpdate represents the payload for adding/removing team members.
+type TeamMemberUpdate struct {
+	Members []string `json:"members"`
+}
+
 // SDKConnection represents a GrowthBook SDK Connection object.
 type SDKConnection struct {
 	ID          string `json:"id,omitempty"`

--- a/internal/growthbookapi/team.go
+++ b/internal/growthbookapi/team.go
@@ -1,0 +1,51 @@
+package growthbookapi
+
+import (
+	"context"
+)
+
+// CreateTeam creates a new team in GrowthBook.
+func (c *Client) CreateTeam(ctx context.Context, t *Team) (*Team, error) {
+	out, err := fetcher[Team](c, "POST", "/teams").One(ctx, t, "team")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetTeam fetches a team by its ID.
+func (c *Client) GetTeam(ctx context.Context, id string) (*Team, error) {
+	out, err := fetcher[Team](c, "GET", "/teams/"+id).One(ctx, nil, "team")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// UpdateTeam updates an existing team by its ID.
+func (c *Client) UpdateTeam(ctx context.Context, id string, t *Team) (*Team, error) {
+	out, err := fetcher[Team](c, "PUT", "/teams/"+id).One(ctx, t, "team")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// DeleteTeam deletes a team by its ID.
+func (c *Client) DeleteTeam(ctx context.Context, id string) error {
+	return c.delete(ctx, "/teams/"+id)
+}
+
+// FindTeamByName searches for a team by its name and returns the first match.
+func (c *Client) FindTeamByName(ctx context.Context, name string) (*Team, error) {
+	teams, err := fetcher[Team](c, "GET", "/teams").All(ctx, nil, "teams")
+	if err != nil {
+		return nil, err
+	}
+	for _, t := range teams {
+		if t.Name == name {
+			return &t, nil
+		}
+	}
+	return nil, ErrNotFound
+}

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -76,6 +76,8 @@ func Provider() *schema.Provider {
 			"growthbook_environment":    resourceEnvironment(),
 			"growthbook_sdk_connection": resourceSDKConnection(),
 			"growthbook_attribute":      resourceAttribute(),
+			"growthbook_team":           resourceTeam(),
+			"growthbook_member_role":    resourceMemberRole(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"growthbook_project":        dataSourceProject(),
@@ -83,6 +85,8 @@ func Provider() *schema.Provider {
 			"growthbook_feature":        dataSourceFeature(),
 			"growthbook_sdk_connection": dataSourceSDKConnection(),
 			"growthbook_attribute":      dataSourceAttribute(),
+			"growthbook_team":           dataSourceTeam(),
+			"growthbook_member":         dataSourceMember(),
 		},
 		ConfigureContextFunc: configureProvider,
 	}

--- a/internal/resource_member_role.go
+++ b/internal/resource_member_role.go
@@ -1,0 +1,151 @@
+package internal
+
+import (
+	"context"
+	"terraform-provider-growthbook/internal/growthbookapi"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceMemberRole() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceMemberRoleCreate,
+		ReadContext:   resourceMemberRoleRead,
+		UpdateContext: resourceMemberRoleUpdate,
+		DeleteContext: resourceMemberRoleDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"email": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The member's email address. Used to look up the existing member.",
+			},
+			"role": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The member's global role (e.g. readonly, collaborator, engineer, analyst, experimenter, admin).",
+			},
+			"limit_access_by_environment": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Whether to restrict access to specific environments.",
+			},
+			"environments": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "List of environments the member has access to. Empty means all.",
+			},
+			"project_roles": projectRolesSchema(),
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The member's display name.",
+			},
+			"teams": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Team IDs the member belongs to.",
+			},
+			"managed_by_idp": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"last_login_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"date_created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"date_updated": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceMemberRoleCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*growthbookapi.Client)
+	email := d.Get("email").(string)
+
+	// Look up the member by email
+	member, err := client.FindMemberByEmail(ctx, email)
+	if err != nil {
+		return diag.Errorf("error finding member with email %s: %v", email, err)
+	}
+
+	// Update the member's role
+	update := &growthbookapi.MemberRoleUpdate{
+		Role:                     d.Get("role").(string),
+		LimitAccessByEnvironment: d.Get("limit_access_by_environment").(bool),
+		Environments:             expandStringList(d.Get("environments").([]interface{})),
+		ProjectRoles:             expandProjectRoles(d.Get("project_roles").([]interface{})),
+	}
+	_, err = client.UpdateMemberRole(ctx, member.ID, update)
+	if err != nil {
+		return diag.Errorf("error updating member role: %v", err)
+	}
+	d.SetId(member.ID)
+
+	return resourceMemberRoleRead(ctx, d, m)
+}
+
+func resourceMemberRoleRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*growthbookapi.Client)
+	member, err := client.GetMember(ctx, d.Id())
+	if err != nil {
+		return diag.Errorf("error reading member: %v", err)
+	}
+	d.Set("email", member.Email)
+	d.Set("name", member.Name)
+	d.Set("role", member.Role)
+	d.Set("limit_access_by_environment", member.LimitAccessByEnvironment)
+	d.Set("environments", member.Environments)
+	d.Set("project_roles", flattenProjectRoles(member.ProjectRoles))
+	d.Set("teams", member.Teams)
+	d.Set("managed_by_idp", member.ManagedByIdp)
+	d.Set("last_login_date", member.LastLoginDate)
+	d.Set("date_created", member.DateCreated)
+	d.Set("date_updated", member.DateUpdated)
+
+	return nil
+}
+
+func resourceMemberRoleUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*growthbookapi.Client)
+	update := &growthbookapi.MemberRoleUpdate{
+		Role:                     d.Get("role").(string),
+		LimitAccessByEnvironment: d.Get("limit_access_by_environment").(bool),
+		Environments:             expandStringList(d.Get("environments").([]interface{})),
+		ProjectRoles:             expandProjectRoles(d.Get("project_roles").([]interface{})),
+	}
+	_, err := client.UpdateMemberRole(ctx, d.Id(), update)
+	if err != nil {
+		return diag.Errorf("error updating member role: %v", err)
+	}
+
+	return resourceMemberRoleRead(ctx, d, m)
+}
+
+func resourceMemberRoleDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*growthbookapi.Client)
+	if err := client.DeleteMember(ctx, d.Id()); err != nil {
+		return diag.Errorf("error removing member from organization: %v", err)
+	}
+	d.SetId("")
+
+	return nil
+}

--- a/internal/resource_team.go
+++ b/internal/resource_team.go
@@ -1,0 +1,220 @@
+package internal
+
+import (
+	"context"
+	"terraform-provider-growthbook/internal/growthbookapi"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func projectRolesSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"project": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "The project ID.",
+				},
+				"role": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "The role for this project.",
+				},
+				"limit_access_by_environment": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Default:     false,
+					Description: "Whether to limit access by environment.",
+				},
+				"environments": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Description: "List of environments the role applies to. " +
+						"Empty means all environments.",
+				},
+			},
+		},
+	}
+}
+
+func expandProjectRoles(raw []interface{}) []growthbookapi.ProjectRole {
+	roles := make([]growthbookapi.ProjectRole, len(raw))
+	for i, v := range raw {
+		m := v.(map[string]interface{})
+		roles[i] = growthbookapi.ProjectRole{
+			Project:                  m["project"].(string),
+			Role:                     m["role"].(string),
+			LimitAccessByEnvironment: m["limit_access_by_environment"].(bool),
+			Environments:             expandStringList(m["environments"].([]interface{})),
+		}
+	}
+	return roles
+}
+
+func flattenProjectRoles(roles []growthbookapi.ProjectRole) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(roles))
+	for i, r := range roles {
+		result[i] = map[string]interface{}{
+			"project":                     r.Project,
+			"role":                        r.Role,
+			"limit_access_by_environment": r.LimitAccessByEnvironment,
+			"environments":                r.Environments,
+		}
+	}
+	return result
+}
+
+func resourceTeam() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTeamCreate,
+		ReadContext:   resourceTeamRead,
+		UpdateContext: resourceTeamUpdate,
+		DeleteContext: resourceTeamDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The team name.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "The team description.",
+			},
+			"role": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The global role for team members (e.g. readonly, collaborator, engineer, analyst, experimenter, admin).",
+			},
+			"limit_access_by_environment": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Whether to restrict team access to specific environments.",
+			},
+			"environments": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "List of environment IDs the team has access to. Empty means all.",
+			},
+			"project_roles": projectRolesSchema(),
+			"members": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Set of member IDs in this team.",
+			},
+			"managed_by_idp": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the team is managed by an identity provider.",
+			},
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The user who created the team.",
+			},
+			"date_created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"date_updated": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceTeamCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*growthbookapi.Client)
+	team := &growthbookapi.Team{
+		Name:                     d.Get("name").(string),
+		Description:              d.Get("description").(string),
+		Role:                     d.Get("role").(string),
+		LimitAccessByEnvironment: d.Get("limit_access_by_environment").(bool),
+		Environments:             expandStringList(d.Get("environments").([]interface{})),
+		ProjectRoles:             expandProjectRoles(d.Get("project_roles").([]interface{})),
+		Members:                  expandStringSet(d.Get("members").(*schema.Set)),
+	}
+	created, err := client.CreateTeam(ctx, team)
+	if err != nil {
+		return diag.Errorf("error creating team: %v", err)
+	}
+	d.SetId(created.ID)
+
+	return resourceTeamRead(ctx, d, m)
+}
+
+func resourceTeamRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*growthbookapi.Client)
+	team, err := client.GetTeam(ctx, d.Id())
+	if err != nil {
+		return diag.Errorf("error reading team: %v", err)
+	}
+	d.Set("name", team.Name)
+	d.Set("description", team.Description)
+	d.Set("role", team.Role)
+	d.Set("limit_access_by_environment", team.LimitAccessByEnvironment)
+	d.Set("environments", team.Environments)
+	d.Set("project_roles", flattenProjectRoles(team.ProjectRoles))
+	d.Set("members", team.Members)
+	d.Set("managed_by_idp", team.ManagedByIdp)
+	d.Set("created_by", team.CreatedBy)
+	d.Set("date_created", team.DateCreated)
+	d.Set("date_updated", team.DateUpdated)
+
+	return nil
+}
+
+func resourceTeamUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*growthbookapi.Client)
+	team := &growthbookapi.Team{
+		Name:                     d.Get("name").(string),
+		Description:              d.Get("description").(string),
+		Role:                     d.Get("role").(string),
+		LimitAccessByEnvironment: d.Get("limit_access_by_environment").(bool),
+		Environments:             expandStringList(d.Get("environments").([]interface{})),
+		ProjectRoles:             expandProjectRoles(d.Get("project_roles").([]interface{})),
+		Members:                  expandStringSet(d.Get("members").(*schema.Set)),
+	}
+	_, err := client.UpdateTeam(ctx, d.Id(), team)
+	if err != nil {
+		return diag.Errorf("error updating team: %v", err)
+	}
+
+	return resourceTeamRead(ctx, d, m)
+}
+
+func resourceTeamDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*growthbookapi.Client)
+	if err := client.DeleteTeam(ctx, d.Id()); err != nil {
+		return diag.Errorf("error deleting team: %v", err)
+	}
+	d.SetId("")
+
+	return nil
+}
+
+func expandStringSet(set *schema.Set) []string {
+	list := set.List()
+	result := make([]string, len(list))
+	for i, v := range list {
+		result[i] = v.(string)
+	}
+	return result
+}


### PR DESCRIPTION
## Summary

- Add `growthbook_team` resource with full CRUD (create, read, update, delete) for managing GrowthBook teams
- Add `growthbook_member_role` resource for managing existing members' roles and permissions (adopt-and-manage pattern, since members can't be created via API)
- Add `growthbook_team` and `growthbook_member` data sources for lookups by name/email
- Add corresponding documentation for all new resources and data sources

### New resources

| Resource | Description |
|---|---|
| `growthbook_team` | Manage teams: name, description, role, environments, project_roles, members |
| `growthbook_member_role` | Manage an existing member's role by email: global role, environments, project_roles |

### New data sources

| Data Source | Description |
|---|---|
| `growthbook_team` | Look up a team by name |
| `growthbook_member` | Look up a member by email |

### API endpoints used

- Teams: `POST/GET/PUT/DELETE /teams`, `GET /teams/{id}`
- Members: `GET /members`, `POST /members/{id}/role`, `DELETE /members/{id}`

### Notes

- `growthbook_member_role` does **not** create/invite members (the GrowthBook API has no invite endpoint). It adopts an existing member by email and manages their role.
- Destroying a `growthbook_member_role` removes the member from the organization.
- All new code follows the existing patterns (generic `fetcher[T]`, `terraform-plugin-sdk/v2`).

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Manual testing with a GrowthBook instance
- [ ] Unit tests (to be added in follow-up)