### PR TITLE
feat: add resources & data sources for 9 new GrowthBook API types

### DIFF
--- a/docs/data-sources/attribute.md
+++ b/docs/data-sources/attribute.md
@@ -1,0 +1,30 @@
+---
+title: "growthbook_attribute Data Source"
+description: |-
+  Provides a GrowthBook Attribute data source.
+---
+
+# growthbook_attribute (Data Source)
+
+Retrieves information about a GrowthBook attribute by property.
+
+## Example Usage
+
+```hcl
+data "growthbook_attribute" "plan" {
+  property = "plan"
+}
+```
+
+## Argument Reference
+
+- `property` (String, Required) – The attribute property key to look up.
+
+## Attributes Reference
+
+- `datatype` (String) – The attribute datatype. Valid values are `boolean`, `string`, `number`, `secureString`, `enum`, `string[]`, `number[]`, and `secureString[]`.
+- `format` (String) – The attribute format. Valid values are ``, `version`, `date`, and `isoCountryCode`.
+- `enum_values` (String) – Comma-separated enum values for enum attributes.
+- `projects` (List(String)) – Array of project IDs that can use this attribute.
+- `archived` (Boolean) – Whether the attribute is archived.
+- `description` (String) – The description of the attribute.

--- a/docs/data-sources/data_source.md
+++ b/docs/data-sources/data_source.md
@@ -1,0 +1,31 @@
+---
+title: "growthbook_data_source Data Source"
+description: |-
+  Provides a GrowthBook Data Source data source.
+---
+
+# growthbook_data_source (Data Source)
+
+Retrieves information about a read-only GrowthBook data source by ID.
+
+## Example Usage
+
+```hcl
+data "growthbook_data_source" "warehouse" {
+  id = "ds_abc123"
+}
+```
+
+## Argument Reference
+
+- `id` (String, Required) – The unique ID of the data source to look up.
+
+## Attributes Reference
+
+- `name` (String) – The name of the data source.
+- `type` (String) – The data source type.
+- `description` (String) – The description of the data source.
+- `project_ids` (List(String)) – Project IDs associated with the data source.
+- `event_tracker` (String) – The data source event tracker.
+- `date_created` (String) – The creation date of the data source.
+- `date_updated` (String) – The last update date of the data source.

--- a/docs/data-sources/dimension.md
+++ b/docs/data-sources/dimension.md
@@ -1,0 +1,33 @@
+---
+title: "growthbook_dimension Data Source"
+description: |-
+  Provides a GrowthBook Dimension data source.
+---
+
+# growthbook_dimension (Data Source)
+
+Retrieves information about a GrowthBook dimension by name.
+
+## Example Usage
+
+```hcl
+data "growthbook_dimension" "country" {
+  name = "Country"
+}
+```
+
+## Argument Reference
+
+- `name` (String, Required) – Name of the dimension to look up.
+
+## Attributes Reference
+
+- `id` (String) – The unique ID of the dimension.
+- `datasource_id` (String) – ID of the data source this dimension belongs to.
+- `identifier_type` (String) – Type of identifier, such as `user_id` or `anonymous_id`.
+- `query` (String) – SQL query or equivalent for the dimension.
+- `description` (String) – Description of the dimension.
+- `owner` (String) – The user ID or email address of the owner.
+- `managed_by` (String) – Where this dimension must be managed from. Valid values are ``, `api`, and `config`.
+- `date_created` (String) – The creation date of the dimension.
+- `date_updated` (String) – The last update date of the dimension.

--- a/docs/data-sources/experiment.md
+++ b/docs/data-sources/experiment.md
@@ -1,0 +1,48 @@
+---
+title: "growthbook_experiment Data Source"
+description: |-
+  Provides a GrowthBook Experiment data source.
+---
+
+# growthbook_experiment (Data Source)
+
+Retrieves information about a GrowthBook experiment by name.
+
+## Example Usage
+
+```hcl
+data "growthbook_experiment" "checkout_cta" {
+  name = "Checkout CTA"
+}
+```
+
+## Argument Reference
+
+- `name` (String, Required) – Name of the experiment to look up.
+
+## Attributes Reference
+
+- `id` (String) – The unique ID of the experiment.
+- `tracking_key` (String) – Tracking key for the experiment.
+- `variations` (String) – JSON-encoded array of experiment variations.
+- `type` (String) – Experiment type. Valid values are `standard` and `multi-armed-bandit`.
+- `project` (String) – Project ID which the experiment belongs to.
+- `hypothesis` (String) – Hypothesis of the experiment.
+- `description` (String) – Description of the experiment.
+- `tags` (List(String)) – Tags associated with the experiment.
+- `owner` (String) – The user ID or email address of the owner.
+- `archived` (Boolean) – Whether the experiment is archived.
+- `status` (String) – Experiment status. Valid values are `draft`, `running`, and `stopped`.
+- `auto_refresh` (Boolean) – Whether experiment results automatically refresh.
+- `hash_attribute` (String) – Attribute used for hashing users into variations.
+- `fallback_attribute` (String) – Fallback attribute used for hashing.
+- `datasource_id` (String) – ID of the data source used for analysis.
+- `assignment_query_id` (String) – ID of an assignment query associated with the data source.
+- `segment_id` (String) – Only users in this segment are included.
+- `metrics` (List(String)) – Primary metric IDs.
+- `secondary_metrics` (List(String)) – Secondary metric IDs.
+- `guardrail_metrics` (List(String)) – Guardrail metric IDs.
+- `stats_engine` (String) – Stats engine. Valid values are `bayesian` and `frequentist`.
+- `phases` (String) – JSON-encoded array of experiment phases.
+- `date_created` (String) – The creation date of the experiment.
+- `date_updated` (String) – The last update date of the experiment.

--- a/docs/data-sources/fact_metric.md
+++ b/docs/data-sources/fact_metric.md
@@ -1,0 +1,48 @@
+---
+title: "growthbook_fact_metric Data Source"
+description: |-
+  Provides a GrowthBook Fact Metric data source.
+---
+
+# growthbook_fact_metric (Data Source)
+
+Retrieves information about a GrowthBook fact metric by name.
+
+## Example Usage
+
+```hcl
+data "growthbook_fact_metric" "revenue_per_user" {
+  name = "Revenue per user"
+}
+```
+
+## Argument Reference
+
+- `name` (String, Required) – Name of the fact metric to look up.
+
+## Attributes Reference
+
+- `id` (String) – The unique ID of the fact metric.
+- `metric_type` (String) – Metric type. Valid values are `proportion`, `retention`, `mean`, `quantile`, `ratio`, and `dailyParticipation`.
+- `numerator` (String) – JSON-encoded numerator definition.
+- `datasource` (String) – The data source ID.
+- `description` (String) – Description of the fact metric.
+- `owner` (String) – The user ID or email address of the owner.
+- `projects` (List(String)) – List of associated project IDs.
+- `tags` (List(String)) – List of associated tags.
+- `denominator` (String) – JSON-encoded denominator definition.
+- `inverse` (Boolean) – Whether lower values are better, such as bounce rate.
+- `capping_settings` (String) – JSON-encoded settings that control how outliers are handled.
+- `window_settings` (String) – JSON-encoded settings that control the conversion window for the metric.
+- `prior_settings` (String) – JSON-encoded Bayesian prior settings.
+- `regression_adjustment_settings` (String) – JSON-encoded regression adjustment (CUPED) settings.
+- `risk_threshold_success` (Number) – Deprecated GrowthBook risk threshold for low risk, as a proportion.
+- `risk_threshold_danger` (Number) – Deprecated GrowthBook risk threshold for high risk, as a proportion.
+- `min_percent_change` (Number) – Minimum percent change to consider uplift significant, as a proportion.
+- `max_percent_change` (Number) – Maximum percent change to consider uplift significant, as a proportion.
+- `min_sample_size` (Number) – Minimum sample size for the metric.
+- `target_mde` (Number) – Percentage change to reliably detect before ending an experiment, as a proportion.
+- `managed_by` (String) – Where this fact metric must be managed from. Valid values are ``, `api`, and `admin`.
+- `archived` (Boolean) – Whether the fact metric is archived.
+- `date_created` (String) – The creation date of the fact metric.
+- `date_updated` (String) – The last update date of the fact metric.

--- a/docs/data-sources/fact_table.md
+++ b/docs/data-sources/fact_table.md
@@ -1,0 +1,37 @@
+---
+title: "growthbook_fact_table Data Source"
+description: |-
+  Provides a GrowthBook Fact Table data source.
+---
+
+# growthbook_fact_table (Data Source)
+
+Retrieves information about a GrowthBook fact table by name.
+
+## Example Usage
+
+```hcl
+data "growthbook_fact_table" "orders" {
+  name = "Orders"
+}
+```
+
+## Argument Reference
+
+- `name` (String, Required) – Name of the fact table to look up.
+
+## Attributes Reference
+
+- `id` (String) – The unique ID of the fact table.
+- `datasource` (String) – The data source ID.
+- `user_id_types` (List(String)) – List of identifier columns in this table, such as `id` or `anonymous_id`.
+- `sql` (String) – The SQL query for this fact table.
+- `description` (String) – Description of the fact table.
+- `owner` (String) – The user ID or email address of the owner.
+- `projects` (List(String)) – List of associated project IDs.
+- `tags` (List(String)) – List of associated tags.
+- `event_name` (String) – The event name used in SQL template variables.
+- `managed_by` (String) – Where this fact table must be managed from. Valid values are ``, `api`, and `admin`.
+- `archived` (Boolean) – Whether the fact table is archived.
+- `date_created` (String) – The creation date of the fact table.
+- `date_updated` (String) – The last update date of the fact table.

--- a/docs/data-sources/metric.md
+++ b/docs/data-sources/metric.md
@@ -1,0 +1,37 @@
+---
+title: "growthbook_metric Data Source"
+description: |-
+  Provides a GrowthBook Metric data source.
+---
+
+# growthbook_metric (Data Source)
+
+Retrieves information about a GrowthBook legacy metric by name.
+
+## Example Usage
+
+```hcl
+data "growthbook_metric" "signup" {
+  name = "Signup conversion"
+}
+```
+
+## Argument Reference
+
+- `name` (String, Required) – Name of the metric to look up.
+
+## Attributes Reference
+
+- `id` (String) – The unique ID of the metric.
+- `datasource_id` (String) – ID of the data source.
+- `type` (String) – Type of metric. Valid values are `binomial`, `count`, `duration`, and `revenue`.
+- `description` (String) – Description of the metric.
+- `owner` (String) – The user ID or email address of the owner.
+- `tags` (List(String)) – List of tags.
+- `projects` (List(String)) – List of project IDs for projects that can access this metric.
+- `archived` (Boolean) – Whether the metric is archived.
+- `behavior` (String) – JSON-encoded behavior settings for the metric.
+- `sql` (String) – JSON-encoded SQL metric definition.
+- `managed_by` (String) – Where this metric must be managed from. Valid values are ``, `api`, `config`, and `admin`.
+- `date_created` (String) – The creation date of the metric.
+- `date_updated` (String) – The last update date of the metric.

--- a/docs/data-sources/namespace.md
+++ b/docs/data-sources/namespace.md
@@ -1,0 +1,30 @@
+---
+title: "growthbook_namespace Data Source"
+description: |-
+  Provides a GrowthBook Namespace data source.
+---
+
+# growthbook_namespace (Data Source)
+
+Retrieves information about a GrowthBook namespace by display name.
+
+## Example Usage
+
+```hcl
+data "growthbook_namespace" "checkout" {
+  display_name = "Checkout experiments"
+}
+```
+
+## Argument Reference
+
+- `display_name` (String, Required) – Human-readable display name of the namespace to look up.
+
+## Attributes Reference
+
+- `id` (String) – The unique internal identifier for the namespace.
+- `description` (String) – Description of the namespace.
+- `status` (String) – Namespace status. Valid values are `active` and `inactive`.
+- `format` (String) – Namespace format. Valid values are `legacy` and `multiRange`.
+- `hash_attribute` (String) – The user attribute used to assign users to namespace buckets.
+- `seed` (String) – The seed used for bucket hashing.

--- a/docs/data-sources/saved_group.md
+++ b/docs/data-sources/saved_group.md
@@ -1,0 +1,34 @@
+---
+title: "growthbook_saved_group Data Source"
+description: |-
+  Provides a GrowthBook Saved Group data source.
+---
+
+# growthbook_saved_group (Data Source)
+
+Retrieves information about a GrowthBook saved group by name.
+
+## Example Usage
+
+```hcl
+data "growthbook_saved_group" "employees" {
+  name = "Employees"
+}
+```
+
+## Argument Reference
+
+- `name` (String, Required) – The display name of the saved group to look up.
+
+## Attributes Reference
+
+- `id` (String) – The unique ID of the saved group.
+- `type` (String) – The type of saved group. Valid values are `condition` and `list`.
+- `condition` (String) – When `type = "condition"`, the JSON-encoded condition for the group.
+- `attribute_key` (String) – When `type = "list"`, the attribute key the group is based on.
+- `values` (List(String)) – When `type = "list"`, the list of values for the attribute key.
+- `owner` (String) – The user ID or email address of the owner.
+- `projects` (List(String)) – Array of project IDs that can use this saved group.
+- `description` (String) – The description of the saved group.
+- `date_created` (String) – The creation date of the saved group.
+- `date_updated` (String) – The last update date of the saved group.

--- a/docs/data-sources/segment.md
+++ b/docs/data-sources/segment.md
@@ -1,0 +1,36 @@
+---
+title: "growthbook_segment Data Source"
+description: |-
+  Provides a GrowthBook Segment data source.
+---
+
+# growthbook_segment (Data Source)
+
+Retrieves information about a GrowthBook segment by name.
+
+## Example Usage
+
+```hcl
+data "growthbook_segment" "active_customers" {
+  name = "Active customers"
+}
+```
+
+## Argument Reference
+
+- `name` (String, Required) – Name of the segment to look up.
+
+## Attributes Reference
+
+- `id` (String) – The unique ID of the segment.
+- `type` (String) – GrowthBook segment type. Valid values are `SQL` and `FACT`.
+- `datasource_id` (String) – ID of the data source this segment belongs to.
+- `identifier_type` (String) – Type of identifier, such as `user_id` or `anonymous_id`.
+- `owner` (String) – The user ID or email address of the owner.
+- `description` (String) – Description of the segment.
+- `query` (String) – SQL query that defines the segment.
+- `fact_table_id` (String) – ID of the fact table for `FACT` segments.
+- `projects` (List(String)) – List of project IDs for projects that can access this segment.
+- `managed_by` (String) – Where this segment must be managed from. Valid values are ``, `api`, and `config`.
+- `date_created` (String) – The creation date of the segment.
+- `date_updated` (String) – The last update date of the segment.

--- a/docs/resources/attribute.md
+++ b/docs/resources/attribute.md
@@ -1,0 +1,45 @@
+---
+title: "growthbook_attribute Resource"
+description: |-
+  Provides a GrowthBook Attribute resource.
+---
+
+# growthbook_attribute
+
+Manages a GrowthBook attribute. Attributes define typed user properties that can be used for targeting, hashing, and analysis.
+
+## Example Usage
+
+```hcl
+resource "growthbook_attribute" "plan" {
+  property    = "plan"
+  datatype    = "enum"
+  format      = ""
+  enum_values = "free,pro,enterprise"
+  description = "Customer subscription plan"
+  projects    = ["project_abc123"]
+  archived    = false
+}
+```
+
+## Argument Reference
+
+- `property` (String, Required) – The attribute property key.
+- `datatype` (String, Required) – The attribute datatype. Valid values are `boolean`, `string`, `number`, `secureString`, `enum`, `string[]`, `number[]`, and `secureString[]`.
+- `format` (String, Optional) – The attribute format. Valid values are ``, `version`, `date`, and `isoCountryCode`.
+- `enum_values` (String, Optional) – Comma-separated enum values for attributes with `datatype = "enum"`.
+- `projects` (List(String), Optional) – Array of project IDs that can use this attribute.
+- `archived` (Boolean, Optional) – Whether the attribute is archived.
+- `description` (String, Optional) – The description of the attribute.
+
+## Attributes Reference
+
+All arguments above are also exported. GrowthBook attributes are identified by `property` and do not have a separate Terraform `id` attribute.
+
+## Import
+
+Attributes can be imported using the attribute property:
+
+```sh
+terraform import growthbook_attribute.example <property>
+```

--- a/docs/resources/dimension.md
+++ b/docs/resources/dimension.md
@@ -1,0 +1,49 @@
+---
+title: "growthbook_dimension Resource"
+description: |-
+  Provides a GrowthBook Dimension resource.
+---
+
+# growthbook_dimension
+
+Manages a GrowthBook dimension. Dimensions define SQL queries used to break experiment results down by user attributes.
+
+## Example Usage
+
+Creation requires a GrowthBook data source ID.
+
+```hcl
+resource "growthbook_dimension" "country" {
+  name            = "Country"
+  datasource_id   = "ds_abc123"
+  identifier_type = "user_id"
+  query           = "SELECT user_id, country FROM users"
+  description     = "User country dimension"
+  owner           = "owner@example.com"
+  managed_by      = "api"
+}
+```
+
+## Argument Reference
+
+- `name` (String, Required) – Name of the dimension.
+- `datasource_id` (String, Required) – ID of the data source this dimension belongs to.
+- `identifier_type` (String, Required) – Type of identifier, such as `user_id` or `anonymous_id`.
+- `query` (String, Required) – SQL query or equivalent for the dimension.
+- `description` (String, Optional) – Description of the dimension.
+- `owner` (String, Optional) – The user ID or email address of the owner.
+- `managed_by` (String, Optional) – Where this dimension must be managed from. Valid values are ``, `api`, and `config`.
+
+## Attributes Reference
+
+- `id` (String) – The unique ID of the dimension.
+- `date_created` (String) – The creation date of the dimension.
+- `date_updated` (String) – The last update date of the dimension.
+
+## Import
+
+Dimensions can be imported using the dimension ID:
+
+```sh
+terraform import growthbook_dimension.example <dimension_id>
+```

--- a/docs/resources/experiment.md
+++ b/docs/resources/experiment.md
@@ -1,0 +1,87 @@
+---
+title: "growthbook_experiment Resource"
+description: |-
+  Provides a GrowthBook Experiment resource.
+---
+
+# growthbook_experiment
+
+Manages a GrowthBook experiment. Experiments define variations, targeting, metrics, status, analysis settings, and rollout phases.
+
+## Example Usage
+
+`variations` and `phases` are JSON-encoded strings.
+
+```hcl
+resource "growthbook_experiment" "checkout_cta" {
+  name         = "Checkout CTA"
+  tracking_key = "checkout-cta"
+  type         = "standard"
+  project      = "project_abc123"
+  hypothesis   = "Changing the CTA increases checkout completion"
+  description  = "CTA copy experiment on checkout"
+  tags         = ["checkout"]
+  owner        = "owner@example.com"
+  status       = "draft"
+
+  datasource_id       = "ds_abc123"
+  assignment_query_id = "assignments"
+  hash_attribute      = "id"
+  metrics             = ["met_signup"]
+  secondary_metrics   = ["met_revenue"]
+  guardrail_metrics   = ["met_refunds"]
+  stats_engine        = "bayesian"
+
+  variations = jsonencode([
+    { id = "0", name = "Control", weight = 0.5 },
+    { id = "1", name = "New CTA", weight = 0.5 }
+  ])
+
+  phases = jsonencode([
+    {
+      name      = "Main"
+      coverage  = 1
+      condition = {}
+    }
+  ])
+}
+```
+
+## Argument Reference
+
+- `name` (String, Required) – Name of the experiment.
+- `tracking_key` (String, Required) – Tracking key for the experiment.
+- `variations` (String, Required) – JSON-encoded array of experiment variations.
+- `type` (String, Optional) – Experiment type. Valid values are `standard` and `multi-armed-bandit`.
+- `project` (String, Optional) – Project ID which the experiment belongs to.
+- `hypothesis` (String, Optional) – Hypothesis of the experiment.
+- `description` (String, Optional) – Description of the experiment.
+- `tags` (List(String), Optional) – Tags associated with the experiment.
+- `owner` (String, Optional) – The user ID or email address of the owner.
+- `archived` (Boolean, Optional) – Whether the experiment is archived.
+- `status` (String, Optional) – Experiment status. Valid values are `draft`, `running`, and `stopped`.
+- `auto_refresh` (Boolean, Optional) – Whether experiment results automatically refresh.
+- `hash_attribute` (String, Optional) – Attribute used for hashing users into variations.
+- `fallback_attribute` (String, Optional) – Fallback attribute used for hashing.
+- `datasource_id` (String, Optional) – ID of the data source used for analysis.
+- `assignment_query_id` (String, Optional) – ID of an assignment query associated with the data source.
+- `segment_id` (String, Optional) – Only users in this segment are included.
+- `metrics` (List(String), Optional) – Primary metric IDs.
+- `secondary_metrics` (List(String), Optional) – Secondary metric IDs.
+- `guardrail_metrics` (List(String), Optional) – Guardrail metric IDs.
+- `stats_engine` (String, Optional) – Stats engine. Valid values are `bayesian` and `frequentist`.
+- `phases` (String, Optional) – JSON-encoded array of experiment phases.
+
+## Attributes Reference
+
+- `id` (String) – The unique ID of the experiment.
+- `date_created` (String) – The creation date of the experiment.
+- `date_updated` (String) – The last update date of the experiment.
+
+## Import
+
+Experiments can be imported using the experiment ID:
+
+```sh
+terraform import growthbook_experiment.example <experiment_id>
+```

--- a/docs/resources/fact_metric.md
+++ b/docs/resources/fact_metric.md
@@ -1,0 +1,82 @@
+---
+title: "growthbook_fact_metric Resource"
+description: |-
+  Provides a GrowthBook Fact Metric resource.
+---
+
+# growthbook_fact_metric
+
+Manages a GrowthBook fact metric. Fact metrics define experiment metrics based on fact tables, including numerator, denominator, capping, window, prior, and regression-adjustment settings.
+
+## Example Usage
+
+Creation requires a GrowthBook data source ID in `datasource`. JSON object fields are provided as JSON-encoded strings.
+
+```hcl
+resource "growthbook_fact_metric" "revenue_per_user" {
+  name        = "Revenue per user"
+  metric_type = "mean"
+  datasource  = "ds_abc123"
+  owner       = "owner@example.com"
+  projects    = ["project_abc123"]
+  tags        = ["revenue"]
+  inverse     = false
+  managed_by  = "api"
+  archived    = false
+
+  numerator = jsonencode({
+    factTableId = "fact_orders"
+    column      = "revenue"
+  })
+
+  capping_settings = jsonencode({
+    type = "none"
+  })
+
+  window_settings = jsonencode({
+    type = "conversion"
+    delayHours = 0
+    windowValue = 72
+    windowUnit = "hours"
+  })
+}
+```
+
+## Argument Reference
+
+- `name` (String, Required) – Name of the fact metric.
+- `metric_type` (String, Required) – Metric type. Valid values are `proportion`, `retention`, `mean`, `quantile`, `ratio`, and `dailyParticipation`.
+- `numerator` (String, Required) – JSON-encoded numerator definition.
+- `datasource` (String, Optional) – The data source ID.
+- `description` (String, Optional) – Description of the fact metric.
+- `owner` (String, Optional) – The user ID or email address of the owner.
+- `projects` (List(String), Optional) – List of associated project IDs.
+- `tags` (List(String), Optional) – List of associated tags.
+- `denominator` (String, Optional) – JSON-encoded denominator definition. Used when `metric_type = "ratio"`.
+- `inverse` (Boolean, Optional) – Set to true for things like bounce rate where you want the metric to decrease.
+- `capping_settings` (String, Optional) – JSON-encoded settings that control how outliers are handled.
+- `window_settings` (String, Optional) – JSON-encoded settings that control the conversion window for the metric.
+- `prior_settings` (String, Optional) – JSON-encoded Bayesian prior settings. If omitted, organization defaults are used.
+- `regression_adjustment_settings` (String, Optional) – JSON-encoded regression adjustment (CUPED) settings.
+- `risk_threshold_success` (Number, Optional) – Deprecated GrowthBook risk threshold for low risk, as a proportion.
+- `risk_threshold_danger` (Number, Optional) – Deprecated GrowthBook risk threshold for high risk, as a proportion.
+- `min_percent_change` (Number, Optional) – Minimum percent change to consider uplift significant, as a proportion.
+- `max_percent_change` (Number, Optional) – Maximum percent change to consider uplift significant, as a proportion.
+- `min_sample_size` (Number, Optional) – Minimum sample size for the metric.
+- `target_mde` (Number, Optional) – Percentage change to reliably detect before ending an experiment, as a proportion.
+- `managed_by` (String, Optional) – Where this fact metric must be managed from. Valid values are ``, `api`, and `admin`.
+- `archived` (Boolean, Optional) – Whether the fact metric is archived.
+
+## Attributes Reference
+
+- `id` (String) – The unique ID of the fact metric.
+- `date_created` (String) – The creation date of the fact metric.
+- `date_updated` (String) – The last update date of the fact metric.
+
+## Import
+
+Fact metrics can be imported using the fact metric ID:
+
+```sh
+terraform import growthbook_fact_metric.example <fact_metric_id>
+```

--- a/docs/resources/fact_table.md
+++ b/docs/resources/fact_table.md
@@ -1,0 +1,57 @@
+---
+title: "growthbook_fact_table Resource"
+description: |-
+  Provides a GrowthBook Fact Table resource.
+---
+
+# growthbook_fact_table
+
+Manages a GrowthBook fact table. Fact tables define reusable SQL event tables used by fact metrics and fact segments.
+
+## Example Usage
+
+Creation requires a GrowthBook data source ID in `datasource`.
+
+```hcl
+resource "growthbook_fact_table" "orders" {
+  name          = "Orders"
+  datasource    = "ds_abc123"
+  user_id_types = ["user_id"]
+  sql           = "SELECT user_id, timestamp, revenue FROM orders"
+  description   = "Order events"
+  owner         = "owner@example.com"
+  projects      = ["project_abc123"]
+  tags          = ["revenue"]
+  event_name    = "Order Completed"
+  managed_by    = "api"
+  archived      = false
+}
+```
+
+## Argument Reference
+
+- `name` (String, Required) – Name of the fact table.
+- `datasource` (String, Required) – The data source ID.
+- `user_id_types` (List(String), Required) – List of identifier columns in this table. For example, `id` or `anonymous_id`.
+- `sql` (String, Required) – The SQL query for this fact table.
+- `description` (String, Optional) – Description of the fact table.
+- `owner` (String, Optional) – The user ID or email address of the owner.
+- `projects` (List(String), Optional) – List of associated project IDs.
+- `tags` (List(String), Optional) – List of associated tags.
+- `event_name` (String, Optional) – The event name used in SQL template variables.
+- `managed_by` (String, Optional) – Where this fact table must be managed from. Valid values are ``, `api`, and `admin`.
+- `archived` (Boolean, Optional) – Whether the fact table is archived.
+
+## Attributes Reference
+
+- `id` (String) – The unique ID of the fact table.
+- `date_created` (String) – The creation date of the fact table.
+- `date_updated` (String) – The last update date of the fact table.
+
+## Import
+
+Fact tables can be imported using the fact table ID:
+
+```sh
+terraform import growthbook_fact_table.example <fact_table_id>
+```

--- a/docs/resources/metric.md
+++ b/docs/resources/metric.md
@@ -1,0 +1,64 @@
+---
+title: "growthbook_metric Resource"
+description: |-
+  Provides a GrowthBook Metric resource.
+---
+
+# growthbook_metric
+
+Manages a GrowthBook legacy metric. Metrics define the SQL or event logic used to analyze experiments.
+
+## Example Usage
+
+Creation requires a GrowthBook data source ID. `behavior` and `sql` are JSON-encoded strings.
+
+```hcl
+resource "growthbook_metric" "signup" {
+  name          = "Signup conversion"
+  datasource_id = "ds_abc123"
+  type          = "binomial"
+  description   = "Users who completed signup"
+  owner         = "owner@example.com"
+  projects      = ["project_abc123"]
+  tags          = ["activation"]
+  archived      = false
+  managed_by    = "api"
+
+  behavior = jsonencode({
+    goal = "increase"
+  })
+
+  sql = jsonencode({
+    userIdType = "user_id"
+    query      = "SELECT user_id, timestamp FROM signups"
+  })
+}
+```
+
+## Argument Reference
+
+- `name` (String, Required) – Name of the metric.
+- `datasource_id` (String, Required) – ID of the data source.
+- `type` (String, Required) – Type of metric. Valid values are `binomial`, `count`, `duration`, and `revenue`.
+- `description` (String, Optional) – Description of the metric.
+- `owner` (String, Optional) – The user ID or email address of the owner.
+- `tags` (List(String), Optional) – List of tags.
+- `projects` (List(String), Optional) – List of project IDs for projects that can access this metric.
+- `archived` (Boolean, Optional) – Whether the metric is archived.
+- `behavior` (String, Optional) – JSON-encoded behavior settings for the metric.
+- `sql` (String, Optional) – JSON-encoded SQL metric definition. The GrowthBook API allows only one of `sql`, `sqlBuilder`, or `mixpanel`; this provider exposes `sql`.
+- `managed_by` (String, Optional) – Where this metric must be managed from. Valid values are ``, `api`, `config`, and `admin`.
+
+## Attributes Reference
+
+- `id` (String) – The unique ID of the metric.
+- `date_created` (String) – The creation date of the metric.
+- `date_updated` (String) – The last update date of the metric.
+
+## Import
+
+Metrics can be imported using the metric ID:
+
+```sh
+terraform import growthbook_metric.example <metric_id>
+```

--- a/docs/resources/namespace.md
+++ b/docs/resources/namespace.md
@@ -1,0 +1,42 @@
+---
+title: "growthbook_namespace Resource"
+description: |-
+  Provides a GrowthBook Namespace resource.
+---
+
+# growthbook_namespace
+
+Manages a GrowthBook namespace. Namespaces reserve mutually exclusive traffic ranges for experiments.
+
+## Example Usage
+
+```hcl
+resource "growthbook_namespace" "checkout" {
+  display_name   = "Checkout experiments"
+  description    = "Mutually exclusive checkout experiments"
+  status         = "active"
+  format         = "multiRange"
+  hash_attribute = "id"
+}
+```
+
+## Argument Reference
+
+- `display_name` (String, Required) – Human-readable display name. Must be unique within the organization.
+- `description` (String, Optional) – Description of the namespace.
+- `status` (String, Optional) – Namespace status. Valid values are `active` and `inactive`.
+- `format` (String, Optional) – Namespace format. Valid values are `legacy` and `multiRange`. `multiRange` supports multiple ranges per experiment and a configurable hash attribute.
+- `hash_attribute` (String, Optional) – Required by GrowthBook when `format = "multiRange"`. The user attribute used to assign users to namespace buckets.
+
+## Attributes Reference
+
+- `id` (String) – The unique internal identifier for the namespace.
+- `seed` (String) – The seed used for bucket hashing.
+
+## Import
+
+Namespaces can be imported using the namespace ID:
+
+```sh
+terraform import growthbook_namespace.example <namespace_id>
+```

--- a/docs/resources/saved_group.md
+++ b/docs/resources/saved_group.md
@@ -1,0 +1,58 @@
+---
+title: "growthbook_saved_group Resource"
+description: |-
+  Provides a GrowthBook Saved Group resource.
+---
+
+# growthbook_saved_group
+
+Manages a GrowthBook saved group. Saved groups define reusable targeting groups based on a JSON condition or a list of attribute values.
+
+## Example Usage
+
+```hcl
+resource "growthbook_saved_group" "employees" {
+  name          = "Employees"
+  type          = "list"
+  attribute_key = "email"
+  values        = ["alice@example.com", "bob@example.com"]
+  owner         = "owner@example.com"
+  projects      = ["project_abc123"]
+  description   = "Internal employee allow list"
+}
+```
+
+For condition-based saved groups, `condition` is a JSON-encoded string:
+
+```hcl
+resource "growthbook_saved_group" "beta_users" {
+  name      = "Beta users"
+  type      = "condition"
+  condition = jsonencode({ beta = true })
+}
+```
+
+## Argument Reference
+
+- `name` (String, Required) – The display name of the saved group.
+- `type` (String, Optional) – The type of saved group. Valid values are `condition` and `list`.
+- `condition` (String, Optional) – When `type = "condition"`, the JSON-encoded condition for the group.
+- `attribute_key` (String, Optional) – When `type = "list"`, the attribute key the group is based on.
+- `values` (List(String), Optional) – When `type = "list"`, the list of values for the attribute key.
+- `owner` (String, Optional) – The user ID or email address of the owner.
+- `projects` (List(String), Optional) – Array of project IDs that can use this saved group.
+- `description` (String, Optional) – The description of the saved group.
+
+## Attributes Reference
+
+- `id` (String) – The unique ID of the saved group.
+- `date_created` (String) – The creation date of the saved group.
+- `date_updated` (String) – The last update date of the saved group.
+
+## Import
+
+Saved groups can be imported using the saved group ID:
+
+```sh
+terraform import growthbook_saved_group.example <saved_group_id>
+```

--- a/docs/resources/segment.md
+++ b/docs/resources/segment.md
@@ -1,0 +1,54 @@
+---
+title: "growthbook_segment Resource"
+description: |-
+  Provides a GrowthBook Segment resource.
+---
+
+# growthbook_segment
+
+Manages a GrowthBook segment. Segments define reusable user cohorts from a data source using SQL or fact table filters.
+
+## Example Usage
+
+Creation requires a GrowthBook data source ID.
+
+```hcl
+resource "growthbook_segment" "active_customers" {
+  name            = "Active customers"
+  type            = "SQL"
+  datasource_id   = "ds_abc123"
+  identifier_type = "user_id"
+  query           = "SELECT user_id FROM users WHERE active = true"
+  owner           = "owner@example.com"
+  description     = "Users with an active account"
+  projects        = ["project_abc123"]
+  managed_by      = "api"
+}
+```
+
+## Argument Reference
+
+- `name` (String, Required) – Name of the segment.
+- `type` (String, Required) – GrowthBook segment type. Valid values are `SQL` and `FACT`.
+- `datasource_id` (String, Required) – ID of the data source this segment belongs to.
+- `identifier_type` (String, Required) – Type of identifier, such as `user_id` or `anonymous_id`.
+- `owner` (String, Optional) – The user ID or email address of the owner.
+- `description` (String, Optional) – Description of the segment.
+- `query` (String, Optional) – SQL query that defines the segment. Required by GrowthBook for `SQL` segments.
+- `fact_table_id` (String, Optional) – ID of the fact table this segment belongs to. Required by GrowthBook for `FACT` segments.
+- `projects` (List(String), Optional) – List of project IDs for projects that can access this segment.
+- `managed_by` (String, Optional) – Where this segment must be managed from. Valid values are ``, `api`, and `config`.
+
+## Attributes Reference
+
+- `id` (String) – The unique ID of the segment.
+- `date_created` (String) – The creation date of the segment.
+- `date_updated` (String) – The last update date of the segment.
+
+## Import
+
+Segments can be imported using the segment ID:
+
+```sh
+terraform import growthbook_segment.example <segment_id>
+```

--- a/internal/data_source_attribute.go
+++ b/internal/data_source_attribute.go
@@ -93,7 +93,7 @@ func (d *attributeDataSource) Read(ctx context.Context, req datasource.ReadReque
 	data.DataType = types.StringValue(attribute.DataType)
 	data.Format = types.StringValue(attribute.Format)
 	data.EnumValues = types.StringValue(attribute.EnumValues)
-	data.Projects = stringsToList(ctx, attribute.Projects)
+	data.Projects = stringsToList(attribute.Projects)
 	data.Archived = types.BoolValue(attribute.Archived)
 	data.Description = types.StringValue(attribute.Description)
 

--- a/internal/data_source_data_source.go
+++ b/internal/data_source_data_source.go
@@ -1,0 +1,88 @@
+package internal
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-growthbook/internal/growthbookapi"
+)
+
+var _ datasource.DataSource = &dataSourceDataSource{}
+
+func newDataSourceDataSource() datasource.DataSource {
+	return &dataSourceDataSource{}
+}
+
+type dataSourceDataSource struct {
+	client *growthbookapi.Client
+}
+
+type dataSourceDataModel struct {
+	ID           types.String `tfsdk:"id"`
+	Name         types.String `tfsdk:"name"`
+	Type         types.String `tfsdk:"type"`
+	Description  types.String `tfsdk:"description"`
+	ProjectIDs   types.List   `tfsdk:"project_ids"`
+	EventTracker types.String `tfsdk:"event_tracker"`
+	DateCreated  types.String `tfsdk:"date_created"`
+	DateUpdated  types.String `tfsdk:"date_updated"`
+}
+
+func (d *dataSourceDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_data_source"
+}
+
+func (d *dataSourceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id":            schema.StringAttribute{Required: true},
+			"name":          schema.StringAttribute{Computed: true},
+			"type":          schema.StringAttribute{Computed: true},
+			"description":   schema.StringAttribute{Computed: true},
+			"project_ids":   schema.ListAttribute{ElementType: types.StringType, Computed: true},
+			"event_tracker": schema.StringAttribute{Computed: true},
+			"date_created":  schema.StringAttribute{Computed: true},
+			"date_updated":  schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (d *dataSourceDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*growthbookapi.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *growthbookapi.Client")
+		return
+	}
+	d.client = client
+}
+
+func (d *dataSourceDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data dataSourceDataModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := d.client.GetDataSource(ctx, data.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to find GrowthBook data source by ID", err.Error())
+		return
+	}
+
+	data.ID = types.StringValue(item.ID)
+	data.Name = types.StringValue(item.Name)
+	data.Type = types.StringValue(item.Type)
+	data.Description = types.StringValue(item.Description)
+	data.ProjectIDs = stringsToList(item.ProjectIDs)
+	data.EventTracker = types.StringValue(item.EventTracker)
+	data.DateCreated = types.StringValue(item.DateCreated)
+	data.DateUpdated = types.StringValue(item.DateUpdated)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/data_source_dimension.go
+++ b/internal/data_source_dimension.go
@@ -1,0 +1,72 @@
+package internal
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+
+	"terraform-provider-growthbook/internal/growthbookapi"
+)
+
+var _ datasource.DataSource = &dimensionDataSource{}
+
+func newDimensionDataSource() datasource.DataSource {
+	return &dimensionDataSource{}
+}
+
+type dimensionDataSource struct {
+	client *growthbookapi.Client
+}
+
+type dimensionDataSourceModel = dimensionModel
+
+func (d *dimensionDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_dimension"
+}
+
+func (d *dimensionDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name":            schema.StringAttribute{Required: true},
+			"id":              schema.StringAttribute{Computed: true},
+			"datasource_id":   schema.StringAttribute{Computed: true},
+			"identifier_type": schema.StringAttribute{Computed: true},
+			"query":           schema.StringAttribute{Computed: true},
+			"description":     schema.StringAttribute{Computed: true},
+			"owner":           schema.StringAttribute{Computed: true},
+			"managed_by":      schema.StringAttribute{Computed: true},
+			"date_created":    schema.StringAttribute{Computed: true},
+			"date_updated":    schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (d *dimensionDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*growthbookapi.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *growthbookapi.Client")
+		return
+	}
+	d.client = client
+}
+
+func (d *dimensionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data dimensionDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := d.client.FindDimensionByName(ctx, data.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to find GrowthBook dimension by name", err.Error())
+		return
+	}
+
+	dimensionModelFromAPI((*dimensionModel)(&data), item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/data_source_environment.go
+++ b/internal/data_source_environment.go
@@ -89,7 +89,7 @@ func (d *environmentDataSource) Read(ctx context.Context, req datasource.ReadReq
 	data.Description = types.StringValue(env.Description)
 	data.ToggleOnList = types.BoolValue(env.ToggleOnList)
 	data.DefaultState = types.BoolValue(env.DefaultState)
-	data.Projects = stringsToList(ctx, env.Projects)
+	data.Projects = stringsToList(env.Projects)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/data_source_environments.go
+++ b/internal/data_source_environments.go
@@ -89,7 +89,7 @@ func (d *environmentsDataSource) Read(ctx context.Context, _ datasource.ReadRequ
 			Description:  types.StringValue(env.Description),
 			ToggleOnList: types.BoolValue(env.ToggleOnList),
 			DefaultState: types.BoolValue(env.DefaultState),
-			Projects:     stringsToList(ctx, env.Projects),
+			Projects:     stringsToList(env.Projects),
 		}
 	}
 

--- a/internal/data_source_experiment.go
+++ b/internal/data_source_experiment.go
@@ -1,0 +1,88 @@
+package internal
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-growthbook/internal/growthbookapi"
+)
+
+var _ datasource.DataSource = &experimentDataSource{}
+
+func newExperimentDataSource() datasource.DataSource {
+	return &experimentDataSource{}
+}
+
+type experimentDataSource struct {
+	client *growthbookapi.Client
+}
+
+type experimentDataSourceModel = experimentModel
+
+func (d *experimentDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_experiment"
+}
+
+func (d *experimentDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name":                schema.StringAttribute{Required: true},
+			"id":                  schema.StringAttribute{Computed: true},
+			"tracking_key":        schema.StringAttribute{Computed: true},
+			"variations":          schema.StringAttribute{Computed: true},
+			"type":                schema.StringAttribute{Computed: true},
+			"project":             schema.StringAttribute{Computed: true},
+			"hypothesis":          schema.StringAttribute{Computed: true},
+			"description":         schema.StringAttribute{Computed: true},
+			"tags":                schema.ListAttribute{ElementType: types.StringType, Computed: true},
+			"owner":               schema.StringAttribute{Computed: true},
+			"archived":            schema.BoolAttribute{Computed: true},
+			"status":              schema.StringAttribute{Computed: true},
+			"auto_refresh":        schema.BoolAttribute{Computed: true},
+			"hash_attribute":      schema.StringAttribute{Computed: true},
+			"fallback_attribute":  schema.StringAttribute{Computed: true},
+			"datasource_id":       schema.StringAttribute{Computed: true},
+			"assignment_query_id": schema.StringAttribute{Computed: true},
+			"segment_id":          schema.StringAttribute{Computed: true},
+			"metrics":             schema.ListAttribute{ElementType: types.StringType, Computed: true},
+			"secondary_metrics":   schema.ListAttribute{ElementType: types.StringType, Computed: true},
+			"guardrail_metrics":   schema.ListAttribute{ElementType: types.StringType, Computed: true},
+			"stats_engine":        schema.StringAttribute{Computed: true},
+			"phases":              schema.StringAttribute{Computed: true},
+			"date_created":        schema.StringAttribute{Computed: true},
+			"date_updated":        schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (d *experimentDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*growthbookapi.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *growthbookapi.Client")
+		return
+	}
+	d.client = client
+}
+
+func (d *experimentDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data experimentDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := d.client.FindExperimentByName(ctx, data.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to find GrowthBook experiment by name", err.Error())
+		return
+	}
+
+	experimentModelFromAPI((*experimentModel)(&data), item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/data_source_fact_metric.go
+++ b/internal/data_source_fact_metric.go
@@ -1,0 +1,88 @@
+package internal
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-growthbook/internal/growthbookapi"
+)
+
+var _ datasource.DataSource = &factMetricDataSource{}
+
+func newFactMetricDataSource() datasource.DataSource {
+	return &factMetricDataSource{}
+}
+
+type factMetricDataSource struct {
+	client *growthbookapi.Client
+}
+
+type factMetricDataSourceModel = factMetricModel
+
+func (d *factMetricDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_fact_metric"
+}
+
+func (d *factMetricDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name":                           schema.StringAttribute{Required: true},
+			"id":                             schema.StringAttribute{Computed: true},
+			"metric_type":                    schema.StringAttribute{Computed: true},
+			"numerator":                      schema.StringAttribute{Computed: true},
+			"datasource":                     schema.StringAttribute{Computed: true},
+			"description":                    schema.StringAttribute{Computed: true},
+			"owner":                          schema.StringAttribute{Computed: true},
+			"projects":                       schema.ListAttribute{ElementType: types.StringType, Computed: true},
+			"tags":                           schema.ListAttribute{ElementType: types.StringType, Computed: true},
+			"denominator":                    schema.StringAttribute{Computed: true},
+			"inverse":                        schema.BoolAttribute{Computed: true},
+			"capping_settings":               schema.StringAttribute{Computed: true},
+			"window_settings":                schema.StringAttribute{Computed: true},
+			"prior_settings":                 schema.StringAttribute{Computed: true},
+			"regression_adjustment_settings": schema.StringAttribute{Computed: true},
+			"risk_threshold_success":         schema.Float64Attribute{Computed: true},
+			"risk_threshold_danger":          schema.Float64Attribute{Computed: true},
+			"min_percent_change":             schema.Float64Attribute{Computed: true},
+			"max_percent_change":             schema.Float64Attribute{Computed: true},
+			"min_sample_size":                schema.Float64Attribute{Computed: true},
+			"target_mde":                     schema.Float64Attribute{Computed: true},
+			"managed_by":                     schema.StringAttribute{Computed: true},
+			"archived":                       schema.BoolAttribute{Computed: true},
+			"date_created":                   schema.StringAttribute{Computed: true},
+			"date_updated":                   schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (d *factMetricDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*growthbookapi.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *growthbookapi.Client")
+		return
+	}
+	d.client = client
+}
+
+func (d *factMetricDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data factMetricDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := d.client.FindFactMetricByName(ctx, data.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to find GrowthBook fact metric by name", err.Error())
+		return
+	}
+
+	factMetricModelFromAPI((*factMetricModel)(&data), item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/data_source_fact_table.go
+++ b/internal/data_source_fact_table.go
@@ -1,0 +1,77 @@
+package internal
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-growthbook/internal/growthbookapi"
+)
+
+var _ datasource.DataSource = &factTableDataSource{}
+
+func newFactTableDataSource() datasource.DataSource {
+	return &factTableDataSource{}
+}
+
+type factTableDataSource struct {
+	client *growthbookapi.Client
+}
+
+type factTableDataSourceModel = factTableModel
+
+func (d *factTableDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_fact_table"
+}
+
+func (d *factTableDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name":          schema.StringAttribute{Required: true},
+			"id":            schema.StringAttribute{Computed: true},
+			"datasource":    schema.StringAttribute{Computed: true},
+			"user_id_types": schema.ListAttribute{ElementType: types.StringType, Computed: true},
+			"sql":           schema.StringAttribute{Computed: true},
+			"description":   schema.StringAttribute{Computed: true},
+			"owner":         schema.StringAttribute{Computed: true},
+			"projects":      schema.ListAttribute{ElementType: types.StringType, Computed: true},
+			"tags":          schema.ListAttribute{ElementType: types.StringType, Computed: true},
+			"event_name":    schema.StringAttribute{Computed: true},
+			"managed_by":    schema.StringAttribute{Computed: true},
+			"archived":      schema.BoolAttribute{Computed: true},
+			"date_created":  schema.StringAttribute{Computed: true},
+			"date_updated":  schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (d *factTableDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*growthbookapi.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *growthbookapi.Client")
+		return
+	}
+	d.client = client
+}
+
+func (d *factTableDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data factTableDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := d.client.FindFactTableByName(ctx, data.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to find GrowthBook fact table by name", err.Error())
+		return
+	}
+
+	factTableModelFromAPI((*factTableModel)(&data), item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/data_source_feature.go
+++ b/internal/data_source_feature.go
@@ -49,15 +49,40 @@ func featureDataEnvironmentSchemaAttr() schema.MapNestedAttribute {
 					Computed: true,
 					NestedObject: schema.NestedAttributeObject{
 						Attributes: map[string]schema.Attribute{
-							"id":             schema.StringAttribute{Computed: true},
-							"type":           schema.StringAttribute{Computed: true},
-							"enabled":        schema.BoolAttribute{Computed: true},
-							"description":    schema.StringAttribute{Computed: true},
-							"condition":      schema.StringAttribute{Computed: true},
-							"value":          schema.StringAttribute{Computed: true},
-							"coverage":       schema.Float64Attribute{Computed: true},
-							"hash_attribute": schema.StringAttribute{Computed: true},
-							"experiment_id":  schema.StringAttribute{Computed: true},
+							"id":                schema.StringAttribute{Computed: true},
+							"type":              schema.StringAttribute{Computed: true},
+							"enabled":           schema.BoolAttribute{Computed: true},
+							"description":       schema.StringAttribute{Computed: true},
+							"condition":         schema.StringAttribute{Computed: true},
+							"value":             schema.StringAttribute{Computed: true},
+							"coverage":          schema.Float64Attribute{Computed: true},
+							"hash_attribute":    schema.StringAttribute{Computed: true},
+							"fallback_attribute": schema.StringAttribute{Computed: true},
+							"hash_version":      schema.Int64Attribute{Computed: true},
+							"seed":              schema.StringAttribute{Computed: true},
+							"tracking_key":      schema.StringAttribute{Computed: true},
+							"schedule_type":     schema.StringAttribute{Computed: true},
+							"namespace": schema.ListNestedAttribute{
+								Computed: true,
+								NestedObject: schema.NestedAttributeObject{
+									Attributes: map[string]schema.Attribute{
+										"enabled":     schema.BoolAttribute{Computed: true},
+										"name":        schema.StringAttribute{Computed: true},
+										"range_start": schema.Float64Attribute{Computed: true},
+										"range_end":   schema.Float64Attribute{Computed: true},
+									},
+								},
+							},
+							"schedule_rules": schema.ListNestedAttribute{
+								Computed: true,
+								NestedObject: schema.NestedAttributeObject{
+									Attributes: map[string]schema.Attribute{
+										"timestamp": schema.StringAttribute{Computed: true},
+										"enabled":   schema.BoolAttribute{Computed: true},
+									},
+								},
+							},
+							"experiment_id": schema.StringAttribute{Computed: true},
 							"variations": schema.ListNestedAttribute{
 								Computed: true,
 								NestedObject: schema.NestedAttributeObject{
@@ -73,6 +98,15 @@ func featureDataEnvironmentSchemaAttr() schema.MapNestedAttribute {
 									Attributes: map[string]schema.Attribute{
 										"id":        schema.StringAttribute{Computed: true},
 										"condition": schema.StringAttribute{Computed: true},
+									},
+								},
+							},
+							"saved_group_targeting": schema.ListNestedAttribute{
+								Computed: true,
+								NestedObject: schema.NestedAttributeObject{
+									Attributes: map[string]schema.Attribute{
+										"match_type":   schema.StringAttribute{Computed: true},
+										"saved_groups": schema.ListAttribute{ElementType: types.StringType, Computed: true},
 									},
 								},
 							},

--- a/internal/data_source_feature.go
+++ b/internal/data_source_feature.go
@@ -49,13 +49,13 @@ func featureDataEnvironmentSchemaAttr() schema.MapNestedAttribute {
 					Computed: true,
 					NestedObject: schema.NestedAttributeObject{
 						Attributes: map[string]schema.Attribute{
-							"id":          schema.StringAttribute{Computed: true},
-							"type":        schema.StringAttribute{Computed: true},
-							"enabled":     schema.BoolAttribute{Computed: true},
-							"description": schema.StringAttribute{Computed: true},
-							"condition":   schema.StringAttribute{Computed: true},
-							"value":       schema.StringAttribute{Computed: true},
-							"coverage":    schema.Float64Attribute{Computed: true},
+							"id":             schema.StringAttribute{Computed: true},
+							"type":           schema.StringAttribute{Computed: true},
+							"enabled":        schema.BoolAttribute{Computed: true},
+							"description":    schema.StringAttribute{Computed: true},
+							"condition":      schema.StringAttribute{Computed: true},
+							"value":          schema.StringAttribute{Computed: true},
+							"coverage":       schema.Float64Attribute{Computed: true},
 							"hash_attribute": schema.StringAttribute{Computed: true},
 							"experiment_id":  schema.StringAttribute{Computed: true},
 							"variations": schema.ListNestedAttribute{
@@ -158,8 +158,8 @@ func (d *featureDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	data.Project = types.StringValue(feature.Project)
 	data.ValueType = types.StringValue(feature.ValueType)
 	data.DefaultValue = types.StringValue(feature.DefaultValue)
-	data.Tags = stringsToList(ctx, feature.Tags)
-	data.Prerequisites = stringsToList(ctx, feature.Prerequisites)
+	data.Tags = stringsToList(feature.Tags)
+	data.Prerequisites = stringsToList(feature.Prerequisites)
 
 	envsMap := envsFromAPI(feature.Environments)
 	var envDiags diag.Diagnostics

--- a/internal/data_source_metric.go
+++ b/internal/data_source_metric.go
@@ -1,0 +1,77 @@
+package internal
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-growthbook/internal/growthbookapi"
+)
+
+var _ datasource.DataSource = &metricDataSource{}
+
+func newMetricDataSource() datasource.DataSource {
+	return &metricDataSource{}
+}
+
+type metricDataSource struct {
+	client *growthbookapi.Client
+}
+
+type metricDataSourceModel = metricModel
+
+func (d *metricDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_metric"
+}
+
+func (d *metricDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name":          schema.StringAttribute{Required: true},
+			"id":            schema.StringAttribute{Computed: true},
+			"datasource_id": schema.StringAttribute{Computed: true},
+			"type":          schema.StringAttribute{Computed: true},
+			"description":   schema.StringAttribute{Computed: true},
+			"owner":         schema.StringAttribute{Computed: true},
+			"tags":          schema.ListAttribute{ElementType: types.StringType, Computed: true},
+			"projects":      schema.ListAttribute{ElementType: types.StringType, Computed: true},
+			"archived":      schema.BoolAttribute{Computed: true},
+			"behavior":      schema.StringAttribute{Computed: true},
+			"sql":           schema.StringAttribute{Computed: true},
+			"managed_by":    schema.StringAttribute{Computed: true},
+			"date_created":  schema.StringAttribute{Computed: true},
+			"date_updated":  schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (d *metricDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*growthbookapi.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *growthbookapi.Client")
+		return
+	}
+	d.client = client
+}
+
+func (d *metricDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data metricDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := d.client.FindMetricByName(ctx, data.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to find GrowthBook metric by name", err.Error())
+		return
+	}
+
+	metricModelFromAPI((*metricModel)(&data), item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/data_source_namespace.go
+++ b/internal/data_source_namespace.go
@@ -1,0 +1,69 @@
+package internal
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+
+	"terraform-provider-growthbook/internal/growthbookapi"
+)
+
+var _ datasource.DataSource = &namespaceDataSource{}
+
+func newNamespaceDataSource() datasource.DataSource {
+	return &namespaceDataSource{}
+}
+
+type namespaceDataSource struct {
+	client *growthbookapi.Client
+}
+
+type namespaceDataSourceModel = namespaceModel
+
+func (d *namespaceDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_namespace"
+}
+
+func (d *namespaceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"display_name":   schema.StringAttribute{Required: true},
+			"id":             schema.StringAttribute{Computed: true},
+			"description":    schema.StringAttribute{Computed: true},
+			"status":         schema.StringAttribute{Computed: true},
+			"format":         schema.StringAttribute{Computed: true},
+			"hash_attribute": schema.StringAttribute{Computed: true},
+			"seed":           schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (d *namespaceDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*growthbookapi.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *growthbookapi.Client")
+		return
+	}
+	d.client = client
+}
+
+func (d *namespaceDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data namespaceDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := d.client.FindNamespaceByDisplayName(ctx, data.DisplayName.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to find GrowthBook namespace by display name", err.Error())
+		return
+	}
+
+	namespaceModelFromAPI((*namespaceModel)(&data), item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/data_source_saved_group.go
+++ b/internal/data_source_saved_group.go
@@ -1,0 +1,74 @@
+package internal
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-growthbook/internal/growthbookapi"
+)
+
+var _ datasource.DataSource = &savedGroupDataSource{}
+
+func newSavedGroupDataSource() datasource.DataSource {
+	return &savedGroupDataSource{}
+}
+
+type savedGroupDataSource struct {
+	client *growthbookapi.Client
+}
+
+type savedGroupDataSourceModel = savedGroupModel
+
+func (d *savedGroupDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_saved_group"
+}
+
+func (d *savedGroupDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name":          schema.StringAttribute{Required: true},
+			"id":            schema.StringAttribute{Computed: true},
+			"type":          schema.StringAttribute{Computed: true},
+			"condition":     schema.StringAttribute{Computed: true},
+			"attribute_key": schema.StringAttribute{Computed: true},
+			"values":        schema.ListAttribute{ElementType: types.StringType, Computed: true},
+			"owner":         schema.StringAttribute{Computed: true},
+			"projects":      schema.ListAttribute{ElementType: types.StringType, Computed: true},
+			"description":   schema.StringAttribute{Computed: true},
+			"date_created":  schema.StringAttribute{Computed: true},
+			"date_updated":  schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (d *savedGroupDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*growthbookapi.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *growthbookapi.Client")
+		return
+	}
+	d.client = client
+}
+
+func (d *savedGroupDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data savedGroupDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := d.client.FindSavedGroupByName(ctx, data.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to find GrowthBook saved group by name", err.Error())
+		return
+	}
+
+	savedGroupModelFromAPI((*savedGroupModel)(&data), item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/data_source_sdk_connection.go
+++ b/internal/data_source_sdk_connection.go
@@ -187,7 +187,7 @@ func (d *sdkConnectionDataSource) Read(ctx context.Context, req datasource.ReadR
 	data.Language = types.StringValue(conn.Language)
 	data.SdkVersion = types.StringValue(conn.SdkVersion)
 	data.Environment = types.StringValue(conn.Environment)
-	data.Projects = stringsToList(ctx, conn.Projects)
+	data.Projects = stringsToList(conn.Projects)
 	data.EncryptPayload = types.BoolValue(conn.EncryptPayload)
 	data.EncryptionKey = types.StringValue(conn.EncryptionKey)
 	data.IncludeVisualExperiments = types.BoolValue(conn.IncludeVisualExperiments)

--- a/internal/data_source_segment.go
+++ b/internal/data_source_segment.go
@@ -1,0 +1,76 @@
+package internal
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-growthbook/internal/growthbookapi"
+)
+
+var _ datasource.DataSource = &segmentDataSource{}
+
+func newSegmentDataSource() datasource.DataSource {
+	return &segmentDataSource{}
+}
+
+type segmentDataSource struct {
+	client *growthbookapi.Client
+}
+
+type segmentDataSourceModel = segmentModel
+
+func (d *segmentDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_segment"
+}
+
+func (d *segmentDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name":            schema.StringAttribute{Required: true},
+			"id":              schema.StringAttribute{Computed: true},
+			"type":            schema.StringAttribute{Computed: true},
+			"datasource_id":   schema.StringAttribute{Computed: true},
+			"identifier_type": schema.StringAttribute{Computed: true},
+			"owner":           schema.StringAttribute{Computed: true},
+			"description":     schema.StringAttribute{Computed: true},
+			"query":           schema.StringAttribute{Computed: true},
+			"fact_table_id":   schema.StringAttribute{Computed: true},
+			"projects":        schema.ListAttribute{ElementType: types.StringType, Computed: true},
+			"managed_by":      schema.StringAttribute{Computed: true},
+			"date_created":    schema.StringAttribute{Computed: true},
+			"date_updated":    schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (d *segmentDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*growthbookapi.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *growthbookapi.Client")
+		return
+	}
+	d.client = client
+}
+
+func (d *segmentDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data segmentDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := d.client.FindSegmentByName(ctx, data.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to find GrowthBook segment by name", err.Error())
+		return
+	}
+
+	segmentModelFromAPI((*segmentModel)(&data), item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/floatutil.go
+++ b/internal/floatutil.go
@@ -1,0 +1,18 @@
+package internal
+
+import "github.com/hashicorp/terraform-plugin-framework/types"
+
+func float64PointerValue(v types.Float64) *float64 {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+	f := v.ValueFloat64()
+	return &f
+}
+
+func float64ValuePointer(v *float64) types.Float64 {
+	if v == nil {
+		return types.Float64Null()
+	}
+	return types.Float64Value(*v)
+}

--- a/internal/growthbookapi/attribute.go
+++ b/internal/growthbookapi/attribute.go
@@ -6,12 +6,12 @@ import (
 )
 
 type AttributeUpdateBody struct {
-	DataType	string	  `json:"datatype"`
-	Format		string	  `json:"format"`
-	EnumValues	string	  `json:"enum"`
-	Projects	[]string  `json:"projects"`
-	Archived	bool	  `json:"archived"`
-	Description	string	  `json:"description"`
+	DataType    string   `json:"datatype"`
+	Format      string   `json:"format"`
+	EnumValues  string   `json:"enum"`
+	Projects    []string `json:"projects"`
+	Archived    bool     `json:"archived"`
+	Description string   `json:"description"`
 }
 
 func (c *Client) CreateAttribute(ctx context.Context, a *Attribute) (*Attribute, error) {
@@ -37,12 +37,12 @@ func (c *Client) GetAttribute(ctx context.Context, property string) (*Attribute,
 
 func (c *Client) UpdateAttribute(ctx context.Context, property string, a *Attribute) (*Attribute, error) {
 	body := &AttributeUpdateBody{
-		DataType: 		a.DataType,
-		Format: 		a.Format,
-		EnumValues:		a.EnumValues,
-		Projects:		a.Projects,
-		Archived:		a.Archived,
-		Description:	a.Description,
+		DataType:    a.DataType,
+		Format:      a.Format,
+		EnumValues:  a.EnumValues,
+		Projects:    a.Projects,
+		Archived:    a.Archived,
+		Description: a.Description,
 	}
 	out, err := fetcher[Attribute](c, "PUT", "/attributes/"+property).One(ctx, body, "attribute")
 	if err != nil {

--- a/internal/growthbookapi/client.go
+++ b/internal/growthbookapi/client.go
@@ -61,6 +61,57 @@ type ClientAPI interface {
 	UpdateAttribute(ctx context.Context, property string, a *Attribute) (*Attribute, error)
 	// DeleteAttribute deletes an attribute by its property
 	DeleteAttribute(ctx context.Context, property string) error
+	// SavedGroup
+	CreateSavedGroup(ctx context.Context, sg *SavedGroup) (*SavedGroup, error)
+	GetSavedGroup(ctx context.Context, id string) (*SavedGroup, error)
+	UpdateSavedGroup(ctx context.Context, id string, sg *SavedGroup) (*SavedGroup, error)
+	DeleteSavedGroup(ctx context.Context, id string) error
+	FindSavedGroupByName(ctx context.Context, name string) (*SavedGroup, error)
+	// Segment
+	CreateSegment(ctx context.Context, s *Segment) (*Segment, error)
+	GetSegment(ctx context.Context, id string) (*Segment, error)
+	UpdateSegment(ctx context.Context, id string, s *Segment) (*Segment, error)
+	DeleteSegment(ctx context.Context, id string) error
+	FindSegmentByName(ctx context.Context, name string) (*Segment, error)
+	// Metric
+	CreateMetric(ctx context.Context, m *Metric) (*Metric, error)
+	GetMetric(ctx context.Context, id string) (*Metric, error)
+	UpdateMetric(ctx context.Context, id string, m *Metric) (*Metric, error)
+	DeleteMetric(ctx context.Context, id string) error
+	FindMetricByName(ctx context.Context, name string) (*Metric, error)
+	// Dimension
+	CreateDimension(ctx context.Context, d *Dimension) (*Dimension, error)
+	GetDimension(ctx context.Context, id string) (*Dimension, error)
+	UpdateDimension(ctx context.Context, id string, d *Dimension) (*Dimension, error)
+	DeleteDimension(ctx context.Context, id string) error
+	FindDimensionByName(ctx context.Context, name string) (*Dimension, error)
+	// FactTable
+	CreateFactTable(ctx context.Context, ft *FactTable) (*FactTable, error)
+	GetFactTable(ctx context.Context, id string) (*FactTable, error)
+	UpdateFactTable(ctx context.Context, id string, ft *FactTable) (*FactTable, error)
+	DeleteFactTable(ctx context.Context, id string) error
+	FindFactTableByName(ctx context.Context, name string) (*FactTable, error)
+	// FactMetric
+	CreateFactMetric(ctx context.Context, fm *FactMetric) (*FactMetric, error)
+	GetFactMetric(ctx context.Context, id string) (*FactMetric, error)
+	UpdateFactMetric(ctx context.Context, id string, fm *FactMetric) (*FactMetric, error)
+	DeleteFactMetric(ctx context.Context, id string) error
+	FindFactMetricByName(ctx context.Context, name string) (*FactMetric, error)
+	// Namespace
+	CreateNamespace(ctx context.Context, ns *Namespace) (*Namespace, error)
+	GetNamespace(ctx context.Context, id string) (*Namespace, error)
+	UpdateNamespace(ctx context.Context, id string, ns *Namespace) (*Namespace, error)
+	DeleteNamespace(ctx context.Context, id string) error
+	FindNamespaceByDisplayName(ctx context.Context, displayName string) (*Namespace, error)
+	// Experiment
+	CreateExperiment(ctx context.Context, e *Experiment) (*Experiment, error)
+	GetExperiment(ctx context.Context, id string) (*Experiment, error)
+	UpdateExperiment(ctx context.Context, id string, e *Experiment) (*Experiment, error)
+	DeleteExperiment(ctx context.Context, id string) error
+	FindExperimentByName(ctx context.Context, name string) (*Experiment, error)
+	// DataSource (read-only)
+	GetDataSource(ctx context.Context, id string) (*DataSource, error)
+	FindDataSourceByName(ctx context.Context, name string) (*DataSource, error)
 }
 
 // BackoffConfig defines the configuration for retrying transient errors.

--- a/internal/growthbookapi/data_source.go
+++ b/internal/growthbookapi/data_source.go
@@ -1,0 +1,24 @@
+package growthbookapi
+
+import "context"
+
+func (c *Client) GetDataSource(ctx context.Context, id string) (*DataSource, error) {
+	out, err := fetcher[DataSource](c, "GET", "/data-sources/"+id).One(ctx, nil, "dataSource")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) FindDataSourceByName(ctx context.Context, name string) (*DataSource, error) {
+	items, err := fetcher[DataSource](c, "GET", "/data-sources").All(ctx, nil, "dataSources")
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		if item.Name == name {
+			return &item, nil
+		}
+	}
+	return nil, ErrNotFound
+}

--- a/internal/growthbookapi/dimension.go
+++ b/internal/growthbookapi/dimension.go
@@ -1,0 +1,44 @@
+package growthbookapi
+
+import "context"
+
+func (c *Client) CreateDimension(ctx context.Context, d *Dimension) (*Dimension, error) {
+	out, err := fetcher[Dimension](c, "POST", "/dimensions").One(ctx, d, "dimension")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) GetDimension(ctx context.Context, id string) (*Dimension, error) {
+	out, err := fetcher[Dimension](c, "GET", "/dimensions/"+id).One(ctx, nil, "dimension")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) UpdateDimension(ctx context.Context, id string, d *Dimension) (*Dimension, error) {
+	out, err := fetcher[Dimension](c, "POST", "/dimensions/"+id).One(ctx, d, "dimension")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) DeleteDimension(ctx context.Context, id string) error {
+	return c.delete(ctx, "/dimensions/"+id)
+}
+
+func (c *Client) FindDimensionByName(ctx context.Context, name string) (*Dimension, error) {
+	items, err := fetcher[Dimension](c, "GET", "/dimensions").All(ctx, nil, "dimensions")
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		if item.Name == name {
+			return &item, nil
+		}
+	}
+	return nil, ErrNotFound
+}

--- a/internal/growthbookapi/experiment.go
+++ b/internal/growthbookapi/experiment.go
@@ -1,0 +1,44 @@
+package growthbookapi
+
+import "context"
+
+func (c *Client) CreateExperiment(ctx context.Context, e *Experiment) (*Experiment, error) {
+	out, err := fetcher[Experiment](c, "POST", "/experiments").One(ctx, e, "experiment")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) GetExperiment(ctx context.Context, id string) (*Experiment, error) {
+	out, err := fetcher[Experiment](c, "GET", "/experiments/"+id).One(ctx, nil, "experiment")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) UpdateExperiment(ctx context.Context, id string, e *Experiment) (*Experiment, error) {
+	out, err := fetcher[Experiment](c, "POST", "/experiments/"+id).One(ctx, e, "experiment")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) DeleteExperiment(ctx context.Context, id string) error {
+	return c.delete(ctx, "/experiments/"+id)
+}
+
+func (c *Client) FindExperimentByName(ctx context.Context, name string) (*Experiment, error) {
+	items, err := fetcher[Experiment](c, "GET", "/experiments").All(ctx, nil, "experiments")
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		if item.Name == name {
+			return &item, nil
+		}
+	}
+	return nil, ErrNotFound
+}

--- a/internal/growthbookapi/fact_metric.go
+++ b/internal/growthbookapi/fact_metric.go
@@ -1,0 +1,44 @@
+package growthbookapi
+
+import "context"
+
+func (c *Client) CreateFactMetric(ctx context.Context, fm *FactMetric) (*FactMetric, error) {
+	out, err := fetcher[FactMetric](c, "POST", "/fact-metrics").One(ctx, fm, "factMetric")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) GetFactMetric(ctx context.Context, id string) (*FactMetric, error) {
+	out, err := fetcher[FactMetric](c, "GET", "/fact-metrics/"+id).One(ctx, nil, "factMetric")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) UpdateFactMetric(ctx context.Context, id string, fm *FactMetric) (*FactMetric, error) {
+	out, err := fetcher[FactMetric](c, "POST", "/fact-metrics/"+id).One(ctx, fm, "factMetric")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) DeleteFactMetric(ctx context.Context, id string) error {
+	return c.delete(ctx, "/fact-metrics/"+id)
+}
+
+func (c *Client) FindFactMetricByName(ctx context.Context, name string) (*FactMetric, error) {
+	items, err := fetcher[FactMetric](c, "GET", "/fact-metrics").All(ctx, nil, "factMetrics")
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		if item.Name == name {
+			return &item, nil
+		}
+	}
+	return nil, ErrNotFound
+}

--- a/internal/growthbookapi/fact_table.go
+++ b/internal/growthbookapi/fact_table.go
@@ -1,0 +1,44 @@
+package growthbookapi
+
+import "context"
+
+func (c *Client) CreateFactTable(ctx context.Context, ft *FactTable) (*FactTable, error) {
+	out, err := fetcher[FactTable](c, "POST", "/fact-tables").One(ctx, ft, "factTable")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) GetFactTable(ctx context.Context, id string) (*FactTable, error) {
+	out, err := fetcher[FactTable](c, "GET", "/fact-tables/"+id).One(ctx, nil, "factTable")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) UpdateFactTable(ctx context.Context, id string, ft *FactTable) (*FactTable, error) {
+	out, err := fetcher[FactTable](c, "POST", "/fact-tables/"+id).One(ctx, ft, "factTable")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) DeleteFactTable(ctx context.Context, id string) error {
+	return c.delete(ctx, "/fact-tables/"+id)
+}
+
+func (c *Client) FindFactTableByName(ctx context.Context, name string) (*FactTable, error) {
+	items, err := fetcher[FactTable](c, "GET", "/fact-tables").All(ctx, nil, "factTables")
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		if item.Name == name {
+			return &item, nil
+		}
+	}
+	return nil, ErrNotFound
+}

--- a/internal/growthbookapi/feature.go
+++ b/internal/growthbookapi/feature.go
@@ -16,6 +16,17 @@ func (c *Client) CreateFeature(ctx context.Context, f *Feature) (*Feature, error
 	if err != nil {
 		return nil, err
 	}
+	if featureNeedsFollowUpUpdate(f) {
+		id := out.ID
+		if id == "" {
+			id = f.ID
+		}
+		updated, err := c.UpdateFeature(ctx, id, f)
+		if err != nil {
+			return nil, err
+		}
+		return updated, nil
+	}
 	return &out, nil
 }
 
@@ -60,4 +71,18 @@ func (c *Client) FindFeatureByName(ctx context.Context, id string) (*Feature, er
 		}
 	}
 	return nil, ErrNotFound
+}
+
+func featureNeedsFollowUpUpdate(f *Feature) bool {
+	if f == nil {
+		return false
+	}
+	for _, env := range f.Environments {
+		for _, rule := range env.Rules {
+			if len(rule.SavedGroupTargeting) > 0 || len(rule.ScheduleRules) > 0 {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/growthbookapi/feature_test.go
+++ b/internal/growthbookapi/feature_test.go
@@ -1,0 +1,221 @@
+package growthbookapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCreateFeatureAppliesSavedGroupTargetingWithFollowUpUpdate(t *testing.T) {
+	t.Parallel()
+
+	var paths []string
+	var updateBody Feature
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.Method + " " + r.URL.Path {
+		case "POST /features":
+			_ = json.NewEncoder(w).Encode(map[string]Feature{
+				"feature": {
+					ID: "feature-id",
+					Environments: map[string]FeatureEnvironmentConfig{
+						"production": {
+							Enabled: true,
+							Rules: []FeatureRule{
+								{ID: "rule-id", Type: "force", Enabled: true},
+							},
+						},
+					},
+				},
+			})
+		case "POST /features/feature-id":
+			if err := json.NewDecoder(r.Body).Decode(&updateBody); err != nil {
+				t.Fatalf("decoding update body: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]Feature{"feature": updateBody})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := &Client{
+		BaseURL:    server.URL,
+		APIKey:     "test-key",
+		HTTPClient: server.Client(),
+	}
+
+	feature := &Feature{
+		ID: "feature-id",
+		Environments: map[string]FeatureEnvironmentConfig{
+			"production": {
+				Enabled: true,
+				Rules: []FeatureRule{
+					{
+						ID:      "rule-id",
+						Type:    "force",
+						Enabled: true,
+						SavedGroupTargeting: []FeatureSavedGroupTargeting{
+							{MatchType: "all", SavedGroups: []string{"saved-group-id"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	created, err := client.CreateFeature(context.Background(), feature)
+	if err != nil {
+		t.Fatalf("CreateFeature returned error: %v", err)
+	}
+
+	if got, want := len(paths), 2; got != want {
+		t.Fatalf("expected %d requests, got %d: %v", want, got, paths)
+	}
+	if got, want := paths[0], "POST /features"; got != want {
+		t.Fatalf("expected first request %q, got %q", want, got)
+	}
+	if got, want := paths[1], "POST /features/feature-id"; got != want {
+		t.Fatalf("expected second request %q, got %q", want, got)
+	}
+	if got := updateBody.Environments["production"].Rules[0].SavedGroupTargeting; len(got) != 1 {
+		t.Fatalf("expected update body to include saved group targeting, got %#v", got)
+	}
+	if got := created.Environments["production"].Rules[0].SavedGroupTargeting; len(got) != 1 {
+		t.Fatalf("expected returned feature to include saved group targeting, got %#v", got)
+	}
+}
+
+func TestCreateFeatureAppliesScheduleRulesWithFollowUpUpdate(t *testing.T) {
+	t.Parallel()
+
+	var paths []string
+	var updateBody Feature
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.Method + " " + r.URL.Path {
+		case "POST /features":
+			_ = json.NewEncoder(w).Encode(map[string]Feature{
+				"feature": {
+					ID: "feature-id",
+					Environments: map[string]FeatureEnvironmentConfig{
+						"production": {
+							Enabled: true,
+							Rules: []FeatureRule{
+								{ID: "rule-id", Type: "force", Enabled: true},
+							},
+						},
+					},
+				},
+			})
+		case "POST /features/feature-id":
+			if err := json.NewDecoder(r.Body).Decode(&updateBody); err != nil {
+				t.Fatalf("decoding update body: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]Feature{"feature": updateBody})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := &Client{
+		BaseURL:    server.URL,
+		APIKey:     "test-key",
+		HTTPClient: server.Client(),
+	}
+
+	timestamp := "2026-06-01T00:00:00Z"
+	feature := &Feature{
+		ID: "feature-id",
+		Environments: map[string]FeatureEnvironmentConfig{
+			"production": {
+				Enabled: true,
+				Rules: []FeatureRule{
+					{
+						ID:      "rule-id",
+						Type:    "force",
+						Enabled: true,
+						ScheduleRules: []FeatureScheduleRule{
+							{Timestamp: &timestamp, Enabled: true},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	created, err := client.CreateFeature(context.Background(), feature)
+	if err != nil {
+		t.Fatalf("CreateFeature returned error: %v", err)
+	}
+
+	if got, want := len(paths), 2; got != want {
+		t.Fatalf("expected %d requests, got %d: %v", want, got, paths)
+	}
+	if got := updateBody.Environments["production"].Rules[0].ScheduleRules; len(got) != 1 {
+		t.Fatalf("expected update body to include schedule rules, got %#v", got)
+	}
+	if got := created.Environments["production"].Rules[0].ScheduleRules; len(got) != 1 {
+		t.Fatalf("expected returned feature to include schedule rules, got %#v", got)
+	}
+}
+
+func TestCreateFeatureSkipsFollowUpUpdateWithoutUpdateOnlyFields(t *testing.T) {
+	t.Parallel()
+
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method != "POST" || r.URL.Path != "/features" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]Feature{
+			"feature": {
+				ID: "feature-id",
+				Environments: map[string]FeatureEnvironmentConfig{
+					"production": {
+						Enabled: true,
+						Rules: []FeatureRule{
+							{ID: "rule-id", Type: "force", Enabled: true},
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := &Client{
+		BaseURL:    server.URL,
+		APIKey:     "test-key",
+		HTTPClient: server.Client(),
+	}
+
+	_, err := client.CreateFeature(context.Background(), &Feature{
+		ID: "feature-id",
+		Environments: map[string]FeatureEnvironmentConfig{
+			"production": {
+				Enabled: true,
+				Rules: []FeatureRule{
+					{ID: "rule-id", Type: "force", Enabled: true},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateFeature returned error: %v", err)
+	}
+	if got, want := requestCount, 1; got != want {
+		t.Fatalf("expected %d request, got %d", want, got)
+	}
+}

--- a/internal/growthbookapi/metric.go
+++ b/internal/growthbookapi/metric.go
@@ -1,0 +1,45 @@
+package growthbookapi
+
+import "context"
+
+func (c *Client) CreateMetric(ctx context.Context, m *Metric) (*Metric, error) {
+	out, err := fetcher[Metric](c, "POST", "/metrics").One(ctx, m, "metric")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) GetMetric(ctx context.Context, id string) (*Metric, error) {
+	out, err := fetcher[Metric](c, "GET", "/metrics/"+id).One(ctx, nil, "metric")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// UpdateMetric sends a PUT and then re-fetches via GET (PUT returns {updatedId} only).
+func (c *Client) UpdateMetric(ctx context.Context, id string, m *Metric) (*Metric, error) {
+	_, err := fetcher[string](c, "PUT", "/metrics/"+id).One(ctx, m, "updatedId")
+	if err != nil {
+		return nil, err
+	}
+	return c.GetMetric(ctx, id)
+}
+
+func (c *Client) DeleteMetric(ctx context.Context, id string) error {
+	return c.delete(ctx, "/metrics/"+id)
+}
+
+func (c *Client) FindMetricByName(ctx context.Context, name string) (*Metric, error) {
+	items, err := fetcher[Metric](c, "GET", "/metrics").All(ctx, nil, "metrics")
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		if item.Name == name {
+			return &item, nil
+		}
+	}
+	return nil, ErrNotFound
+}

--- a/internal/growthbookapi/models.go
+++ b/internal/growthbookapi/models.go
@@ -1,5 +1,9 @@
 package growthbookapi
 
+import (
+	"encoding/json"
+)
+
 // Project represents a GrowthBook project object.
 type Project struct {
 	ID          string          `json:"id,omitempty"`
@@ -131,4 +135,167 @@ type SDKConnection struct {
 	SseEnabled      bool   `json:"sseEnabled,omitempty"`
 	DateCreated     string `json:"dateCreated,omitempty"`
 	DateUpdated     string `json:"dateUpdated,omitempty"`
+}
+
+// SavedGroup represents a GrowthBook saved group.
+type SavedGroup struct {
+	ID           string   `json:"id,omitempty"`
+	Name         string   `json:"name"`
+	Type         string   `json:"type,omitempty"`
+	Condition    string   `json:"condition,omitempty"`
+	AttributeKey string   `json:"attributeKey,omitempty"`
+	Values       []string `json:"values,omitempty"`
+	Owner        string   `json:"owner,omitempty"`
+	Projects     []string `json:"projects,omitempty"`
+	Description  string   `json:"description,omitempty"`
+	DateCreated  string   `json:"dateCreated,omitempty"`
+	DateUpdated  string   `json:"dateUpdated,omitempty"`
+}
+
+// Segment represents a GrowthBook segment.
+type Segment struct {
+	ID             string   `json:"id,omitempty"`
+	Name           string   `json:"name"`
+	Owner          string   `json:"owner,omitempty"`
+	Description    string   `json:"description,omitempty"`
+	DatasourceID   string   `json:"datasourceId,omitempty"`
+	IdentifierType string   `json:"identifierType,omitempty"`
+	Type           string   `json:"type,omitempty"`
+	Query          string   `json:"query,omitempty"`
+	FactTableID    string   `json:"factTableId,omitempty"`
+	Projects       []string `json:"projects,omitempty"`
+	ManagedBy      string   `json:"managedBy,omitempty"`
+	DateCreated    string   `json:"dateCreated,omitempty"`
+	DateUpdated    string   `json:"dateUpdated,omitempty"`
+}
+
+// Metric represents a GrowthBook (legacy) metric.
+type Metric struct {
+	ID           string          `json:"id,omitempty"`
+	Name         string          `json:"name"`
+	Description  string          `json:"description,omitempty"`
+	Owner        string          `json:"owner,omitempty"`
+	DatasourceID string          `json:"datasourceId,omitempty"`
+	Type         string          `json:"type,omitempty"`
+	Tags         []string        `json:"tags,omitempty"`
+	Projects     []string        `json:"projects,omitempty"`
+	Archived     bool            `json:"archived"`
+	Behavior     json.RawMessage `json:"behavior,omitempty"`
+	SQL          json.RawMessage `json:"sql,omitempty"`
+	ManagedBy    string          `json:"managedBy,omitempty"`
+	DateCreated  string          `json:"dateCreated,omitempty"`
+	DateUpdated  string          `json:"dateUpdated,omitempty"`
+}
+
+// Dimension represents a GrowthBook dimension.
+type Dimension struct {
+	ID             string `json:"id,omitempty"`
+	Name           string `json:"name"`
+	Description    string `json:"description,omitempty"`
+	Owner          string `json:"owner,omitempty"`
+	DatasourceID   string `json:"datasourceId,omitempty"`
+	IdentifierType string `json:"identifierType,omitempty"`
+	Query          string `json:"query,omitempty"`
+	ManagedBy      string `json:"managedBy,omitempty"`
+	DateCreated    string `json:"dateCreated,omitempty"`
+	DateUpdated    string `json:"dateUpdated,omitempty"`
+}
+
+// FactTable represents a GrowthBook fact table.
+type FactTable struct {
+	ID          string   `json:"id,omitempty"`
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Owner       string   `json:"owner,omitempty"`
+	Projects    []string `json:"projects,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	Datasource  string   `json:"datasource,omitempty"`
+	UserIDTypes []string `json:"userIdTypes,omitempty"`
+	SQL         string   `json:"sql,omitempty"`
+	EventName   string   `json:"eventName,omitempty"`
+	ManagedBy   string   `json:"managedBy,omitempty"`
+	Archived    bool     `json:"archived"`
+	DateCreated string   `json:"dateCreated,omitempty"`
+	DateUpdated string   `json:"dateUpdated,omitempty"`
+}
+
+// FactMetric represents a GrowthBook fact metric.
+type FactMetric struct {
+	ID                           string          `json:"id,omitempty"`
+	Name                         string          `json:"name"`
+	Description                  string          `json:"description,omitempty"`
+	Owner                        string          `json:"owner,omitempty"`
+	Projects                     []string        `json:"projects,omitempty"`
+	Tags                         []string        `json:"tags,omitempty"`
+	Datasource                   string          `json:"datasource,omitempty"`
+	MetricType                   string          `json:"metricType,omitempty"`
+	Numerator                    json.RawMessage `json:"numerator,omitempty"`
+	Denominator                  json.RawMessage `json:"denominator,omitempty"`
+	Inverse                      bool            `json:"inverse"`
+	CappingSettings              json.RawMessage `json:"cappingSettings,omitempty"`
+	WindowSettings               json.RawMessage `json:"windowSettings,omitempty"`
+	PriorSettings                json.RawMessage `json:"priorSettings,omitempty"`
+	RegressionAdjustmentSettings json.RawMessage `json:"regressionAdjustmentSettings,omitempty"`
+	RiskThresholdSuccess         *float64        `json:"riskThresholdSuccess,omitempty"`
+	RiskThresholdDanger          *float64        `json:"riskThresholdDanger,omitempty"`
+	MinPercentChange             *float64        `json:"minPercentChange,omitempty"`
+	MaxPercentChange             *float64        `json:"maxPercentChange,omitempty"`
+	MinSampleSize                *float64        `json:"minSampleSize,omitempty"`
+	TargetMDE                    *float64        `json:"targetMDE,omitempty"`
+	ManagedBy                    string          `json:"managedBy,omitempty"`
+	Archived                     bool            `json:"archived"`
+	DateCreated                  string          `json:"dateCreated,omitempty"`
+	DateUpdated                  string          `json:"dateUpdated,omitempty"`
+}
+
+// Namespace represents a GrowthBook namespace.
+type Namespace struct {
+	ID            string `json:"id,omitempty"`
+	DisplayName   string `json:"displayName,omitempty"`
+	Description   string `json:"description,omitempty"`
+	Status        string `json:"status,omitempty"`
+	Format        string `json:"format,omitempty"`
+	HashAttribute string `json:"hashAttribute,omitempty"`
+	Seed          string `json:"seed,omitempty"`
+}
+
+// Experiment represents a GrowthBook experiment.
+type Experiment struct {
+	ID                string          `json:"id,omitempty"`
+	Name              string          `json:"name"`
+	TrackingKey       string          `json:"trackingKey,omitempty"`
+	Type              string          `json:"type,omitempty"`
+	Project           string          `json:"project,omitempty"`
+	Hypothesis        string          `json:"hypothesis,omitempty"`
+	Description       string          `json:"description,omitempty"`
+	Tags              []string        `json:"tags,omitempty"`
+	Owner             string          `json:"owner,omitempty"`
+	Archived          bool            `json:"archived"`
+	Status            string          `json:"status,omitempty"`
+	AutoRefresh       bool            `json:"autoRefresh"`
+	HashAttribute     string          `json:"hashAttribute,omitempty"`
+	FallbackAttribute string          `json:"fallbackAttribute,omitempty"`
+	DatasourceID      string          `json:"datasourceId,omitempty"`
+	AssignmentQueryID string          `json:"assignmentQueryId,omitempty"`
+	SegmentID         string          `json:"segmentId,omitempty"`
+	Metrics           []string        `json:"metrics,omitempty"`
+	SecondaryMetrics  []string        `json:"secondaryMetrics,omitempty"`
+	GuardrailMetrics  []string        `json:"guardrailMetrics,omitempty"`
+	StatsEngine       string          `json:"statsEngine,omitempty"`
+	Variations        json.RawMessage `json:"variations,omitempty"`
+	Phases            json.RawMessage `json:"phases,omitempty"`
+	DateCreated       string          `json:"dateCreated,omitempty"`
+	DateUpdated       string          `json:"dateUpdated,omitempty"`
+}
+
+// DataSource represents a GrowthBook data source (read-only).
+type DataSource struct {
+	ID           string   `json:"id,omitempty"`
+	Name         string   `json:"name,omitempty"`
+	Type         string   `json:"type,omitempty"`
+	Description  string   `json:"description,omitempty"`
+	ProjectIDs   []string `json:"projectIds,omitempty"`
+	EventTracker string   `json:"eventTracker,omitempty"`
+	DateCreated  string   `json:"dateCreated,omitempty"`
+	DateUpdated  string   `json:"dateUpdated,omitempty"`
 }

--- a/internal/growthbookapi/models.go
+++ b/internal/growthbookapi/models.go
@@ -50,14 +50,34 @@ type FeatureRule struct {
 	Condition   string `json:"condition,omitempty"`
 	// force / rollout
 	Value string `json:"value,omitempty"`
-	// rollout only
-	Coverage      *float64 `json:"coverage,omitempty"`
-	HashAttribute string   `json:"hashAttribute,omitempty"`
+	// rollout / experiment
+	Coverage          *float64              `json:"coverage,omitempty"`
+	HashAttribute     string                `json:"hashAttribute,omitempty"`
+	FallbackAttribute string                `json:"fallbackAttribute,omitempty"`
+	HashVersion       *int                  `json:"hashVersion,omitempty"`
+	Seed              string                `json:"seed,omitempty"`
+	Namespace         *FeatureNamespace     `json:"namespace,omitempty"`
+	TrackingKey       string                `json:"trackingKey,omitempty"`
+	ScheduleRules     []FeatureScheduleRule `json:"scheduleRules,omitempty"`
+	ScheduleType      string                `json:"scheduleType,omitempty"`
 	// experiment-ref only
 	ExperimentID        string                       `json:"experimentId,omitempty"`
 	Variations          []FeatureVariation           `json:"variations,omitempty"`
 	SavedGroupTargeting []FeatureSavedGroupTargeting `json:"savedGroupTargeting,omitempty"`
 	Prerequisites       []FeaturePrerequisite        `json:"prerequisites,omitempty"`
+}
+
+// FeatureNamespace represents a traffic namespace for a rule.
+type FeatureNamespace struct {
+	Enabled bool       `json:"enabled"`
+	Name    string     `json:"name"`
+	Range   [2]float64 `json:"range,omitempty"`
+}
+
+// FeatureScheduleRule represents a time-based schedule entry for a rule.
+type FeatureScheduleRule struct {
+	Timestamp *string `json:"timestamp"`
+	Enabled   bool    `json:"enabled"`
 }
 
 // FeatureVariation represents a single variation in an experiment-ref rule.

--- a/internal/growthbookapi/namespace.go
+++ b/internal/growthbookapi/namespace.go
@@ -1,0 +1,44 @@
+package growthbookapi
+
+import "context"
+
+func (c *Client) CreateNamespace(ctx context.Context, ns *Namespace) (*Namespace, error) {
+	out, err := fetcher[Namespace](c, "POST", "/namespaces").One(ctx, ns, "namespace")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) GetNamespace(ctx context.Context, id string) (*Namespace, error) {
+	out, err := fetcher[Namespace](c, "GET", "/namespaces/"+id).One(ctx, nil, "namespace")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) UpdateNamespace(ctx context.Context, id string, ns *Namespace) (*Namespace, error) {
+	out, err := fetcher[Namespace](c, "PUT", "/namespaces/"+id).One(ctx, ns, "namespace")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) DeleteNamespace(ctx context.Context, id string) error {
+	return c.delete(ctx, "/namespaces/"+id)
+}
+
+func (c *Client) FindNamespaceByDisplayName(ctx context.Context, displayName string) (*Namespace, error) {
+	items, err := fetcher[Namespace](c, "GET", "/namespaces").All(ctx, nil, "namespaces")
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		if item.DisplayName == displayName {
+			return &item, nil
+		}
+	}
+	return nil, ErrNotFound
+}

--- a/internal/growthbookapi/saved_group.go
+++ b/internal/growthbookapi/saved_group.go
@@ -1,0 +1,44 @@
+package growthbookapi
+
+import "context"
+
+func (c *Client) CreateSavedGroup(ctx context.Context, sg *SavedGroup) (*SavedGroup, error) {
+	out, err := fetcher[SavedGroup](c, "POST", "/saved-groups").One(ctx, sg, "savedGroup")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) GetSavedGroup(ctx context.Context, id string) (*SavedGroup, error) {
+	out, err := fetcher[SavedGroup](c, "GET", "/saved-groups/"+id).One(ctx, nil, "savedGroup")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) UpdateSavedGroup(ctx context.Context, id string, sg *SavedGroup) (*SavedGroup, error) {
+	out, err := fetcher[SavedGroup](c, "POST", "/saved-groups/"+id).One(ctx, sg, "savedGroup")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) DeleteSavedGroup(ctx context.Context, id string) error {
+	return c.delete(ctx, "/saved-groups/"+id)
+}
+
+func (c *Client) FindSavedGroupByName(ctx context.Context, name string) (*SavedGroup, error) {
+	items, err := fetcher[SavedGroup](c, "GET", "/saved-groups").All(ctx, nil, "savedGroups")
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		if item.Name == name {
+			return &item, nil
+		}
+	}
+	return nil, ErrNotFound
+}

--- a/internal/growthbookapi/segment.go
+++ b/internal/growthbookapi/segment.go
@@ -1,0 +1,44 @@
+package growthbookapi
+
+import "context"
+
+func (c *Client) CreateSegment(ctx context.Context, s *Segment) (*Segment, error) {
+	out, err := fetcher[Segment](c, "POST", "/segments").One(ctx, s, "segment")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) GetSegment(ctx context.Context, id string) (*Segment, error) {
+	out, err := fetcher[Segment](c, "GET", "/segments/"+id).One(ctx, nil, "segment")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) UpdateSegment(ctx context.Context, id string, s *Segment) (*Segment, error) {
+	out, err := fetcher[Segment](c, "POST", "/segments/"+id).One(ctx, s, "segment")
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) DeleteSegment(ctx context.Context, id string) error {
+	return c.delete(ctx, "/segments/"+id)
+}
+
+func (c *Client) FindSegmentByName(ctx context.Context, name string) (*Segment, error) {
+	items, err := fetcher[Segment](c, "GET", "/segments").All(ctx, nil, "segments")
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		if item.Name == name {
+			return &item, nil
+		}
+	}
+	return nil, ErrNotFound
+}

--- a/internal/jsonutil.go
+++ b/internal/jsonutil.go
@@ -1,0 +1,32 @@
+package internal
+
+import (
+	"encoding/json"
+)
+
+// rawJSONToString converts json.RawMessage to a normalized JSON string.
+// Returns empty string if msg is nil or empty.
+func rawJSONToString(msg json.RawMessage) string {
+	if len(msg) == 0 {
+		return ""
+	}
+
+	var v any
+	if err := json.Unmarshal(msg, &v); err != nil {
+		return string(msg)
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return string(msg)
+	}
+	return string(b)
+}
+
+// stringToRawJSON converts a JSON string to json.RawMessage.
+// Returns nil if s is empty.
+func stringToRawJSON(s string) json.RawMessage {
+	if s == "" {
+		return nil
+	}
+	return json.RawMessage(s)
+}

--- a/internal/jsonvalidator.go
+++ b/internal/jsonvalidator.go
@@ -1,0 +1,41 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// jsonStringValidator validates that a string attribute contains valid JSON.
+type jsonStringValidator struct{}
+
+// JSONString returns a validator that ensures the string is valid JSON.
+func JSONString() validator.String {
+	return jsonStringValidator{}
+}
+
+func (v jsonStringValidator) Description(_ context.Context) string {
+	return "value must be a valid JSON string"
+}
+
+func (v jsonStringValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v jsonStringValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	s := req.ConfigValue.ValueString()
+	if s == "" {
+		return
+	}
+	if !json.Valid([]byte(s)) {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid JSON",
+			"The value must be a valid JSON string. Use `jsonencode({...})` to construct it.",
+		)
+	}
+}

--- a/internal/listutil.go
+++ b/internal/listutil.go
@@ -1,0 +1,31 @@
+package internal
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func stringsToList(strs []string) types.List {
+	if len(strs) == 0 {
+		return types.ListValueMust(types.StringType, []attr.Value{})
+	}
+	vals := make([]attr.Value, len(strs))
+	for i, s := range strs {
+		vals[i] = types.StringValue(s)
+	}
+	return types.ListValueMust(types.StringType, vals)
+}
+
+func listToStrings(list types.List) []string {
+	if list.IsNull() || list.IsUnknown() {
+		return nil
+	}
+	elems := list.Elements()
+	strs := make([]string, 0, len(elems))
+	for _, e := range elems {
+		if s, ok := e.(types.String); ok {
+			strs = append(strs, s.ValueString())
+		}
+	}
+	return strs
+}

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -171,6 +171,14 @@ func (p *growthbookProvider) Resources(_ context.Context) []func() resource.Reso
 		newEnvironmentResource,
 		newSDKConnectionResource,
 		newAttributeResource,
+		newSavedGroupResource,
+		newSegmentResource,
+		newMetricResource,
+		newDimensionResource,
+		newFactTableResource,
+		newFactMetricResource,
+		newNamespaceResource,
+		newExperimentResource,
 	}
 }
 
@@ -181,5 +189,14 @@ func (p *growthbookProvider) DataSources(_ context.Context) []func() datasource.
 		newFeatureDataSource,
 		newSDKConnectionDataSource,
 		newAttributeDataSource,
+		newSavedGroupDataSource,
+		newSegmentDataSource,
+		newMetricDataSource,
+		newDimensionDataSource,
+		newFactTableDataSource,
+		newFactMetricDataSource,
+		newNamespaceDataSource,
+		newExperimentDataSource,
+		newDataSourceDataSource,
 	}
 }

--- a/internal/resource_attribute.go
+++ b/internal/resource_attribute.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"slices"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -130,7 +131,7 @@ func (r *attributeResource) Create(ctx context.Context, req resource.CreateReque
 	data.DataType = types.StringValue(created.DataType)
 	data.Format = types.StringValue(created.Format)
 	data.EnumValues = types.StringValue(created.EnumValues)
-	data.Projects = stringsToList(ctx, created.Projects)
+	data.Projects = stringsToList(created.Projects)
 	data.Archived = types.BoolValue(created.Archived)
 	data.Description = types.StringValue(created.Description)
 
@@ -146,11 +147,15 @@ func (r *attributeResource) Read(ctx context.Context, req resource.ReadRequest, 
 
 	out, err := r.client.GetAttribute(ctx, data.Property.ValueString())
 	if err != nil {
+		if errors.Is(err, growthbookapi.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Error reading attribute", err.Error())
 		return
 	}
 	if out == nil {
-		resp.Diagnostics.AddError("Attribute not found", "Attribute with property '"+data.Property.ValueString()+"' was not found.")
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -158,7 +163,7 @@ func (r *attributeResource) Read(ctx context.Context, req resource.ReadRequest, 
 	data.DataType = types.StringValue(out.DataType)
 	data.Format = types.StringValue(out.Format)
 	data.EnumValues = types.StringValue(out.EnumValues)
-	data.Projects = stringsToList(ctx, out.Projects)
+	data.Projects = stringsToList(out.Projects)
 	data.Archived = types.BoolValue(out.Archived)
 	data.Description = types.StringValue(out.Description)
 

--- a/internal/resource_data_source_test.go
+++ b/internal/resource_data_source_test.go
@@ -1,0 +1,36 @@
+package internal_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func testAccDataSourceConfig(id string) string {
+	return `
+data "growthbook_data_source" "by_id" {
+  id = "` + id + `"
+}
+`
+}
+
+func TestAccDataSource_basic(t *testing.T) {
+	t.Parallel()
+
+	id := os.Getenv("GROWTHBOOK_TEST_DATASOURCE_ID")
+	if id == "" {
+		t.Skip("GROWTHBOOK_TEST_DATASOURCE_ID not set")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{{
+			Config: testAccDataSourceConfig(id),
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("data.growthbook_data_source.by_id", "id", id),
+			),
+		}},
+	})
+}

--- a/internal/resource_dimension.go
+++ b/internal/resource_dimension.go
@@ -1,0 +1,178 @@
+package internal
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-growthbook/internal/growthbookapi"
+)
+
+var _ resource.Resource = &dimensionResource{}
+var _ resource.ResourceWithImportState = &dimensionResource{}
+
+func newDimensionResource() resource.Resource {
+	return &dimensionResource{}
+}
+
+type dimensionResource struct {
+	client *growthbookapi.Client
+}
+
+type dimensionModel struct {
+	ID             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	DatasourceID   types.String `tfsdk:"datasource_id"`
+	IdentifierType types.String `tfsdk:"identifier_type"`
+	Query          types.String `tfsdk:"query"`
+	Description    types.String `tfsdk:"description"`
+	Owner          types.String `tfsdk:"owner"`
+	ManagedBy      types.String `tfsdk:"managed_by"`
+	DateCreated    types.String `tfsdk:"date_created"`
+	DateUpdated    types.String `tfsdk:"date_updated"`
+}
+
+func (r *dimensionResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_dimension"
+}
+
+func (r *dimensionResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id":              schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"name":            schema.StringAttribute{Required: true},
+			"datasource_id":   schema.StringAttribute{Required: true},
+			"identifier_type": schema.StringAttribute{Required: true},
+			"query":           schema.StringAttribute{Required: true},
+			"description":     schema.StringAttribute{Optional: true, Computed: true},
+			"owner":           schema.StringAttribute{Optional: true, Computed: true},
+			"managed_by":      schema.StringAttribute{Optional: true, Computed: true},
+			"date_created":    schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"date_updated":    schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (r *dimensionResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*growthbookapi.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *growthbookapi.Client")
+		return
+	}
+	r.client = client
+}
+
+func dimensionFromModel(data dimensionModel) *growthbookapi.Dimension {
+	return &growthbookapi.Dimension{
+		Name:           data.Name.ValueString(),
+		DatasourceID:   data.DatasourceID.ValueString(),
+		IdentifierType: data.IdentifierType.ValueString(),
+		Query:          data.Query.ValueString(),
+		Description:    data.Description.ValueString(),
+		Owner:          data.Owner.ValueString(),
+		ManagedBy:      data.ManagedBy.ValueString(),
+	}
+}
+
+func dimensionModelFromAPI(data *dimensionModel, item *growthbookapi.Dimension) {
+	data.ID = types.StringValue(item.ID)
+	data.Name = types.StringValue(item.Name)
+	data.DatasourceID = types.StringValue(item.DatasourceID)
+	data.IdentifierType = types.StringValue(item.IdentifierType)
+	data.Query = types.StringValue(item.Query)
+	data.Description = types.StringValue(item.Description)
+	data.Owner = types.StringValue(item.Owner)
+	data.ManagedBy = types.StringValue(item.ManagedBy)
+	data.DateCreated = types.StringValue(item.DateCreated)
+	data.DateUpdated = types.StringValue(item.DateUpdated)
+}
+
+func (r *dimensionResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data dimensionModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.CreateDimension(ctx, dimensionFromModel(data))
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating dimension", err.Error())
+		return
+	}
+
+	dimensionModelFromAPI(&data, item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *dimensionResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data dimensionModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.GetDimension(ctx, data.ID.ValueString())
+	if err != nil {
+		if errors.Is(err, growthbookapi.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading dimension", err.Error())
+		return
+	}
+
+	dimensionModelFromAPI(&data, item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *dimensionResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data dimensionModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state dimensionModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.UpdateDimension(ctx, state.ID.ValueString(), dimensionFromModel(data))
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating dimension", err.Error())
+		return
+	}
+
+	dimensionModelFromAPI(&data, item)
+	data.ID = state.ID
+	if data.DateCreated.ValueString() == "" {
+		data.DateCreated = state.DateCreated
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *dimensionResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data dimensionModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.DeleteDimension(ctx, data.ID.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error deleting dimension", err.Error())
+	}
+}
+
+func (r *dimensionResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/resource_dimension_test.go
+++ b/internal/resource_dimension_test.go
@@ -1,0 +1,71 @@
+package internal_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func testAccDimensionConfig(name, datasourceID string) string {
+	return `
+resource "growthbook_dimension" "test" {
+  name            = "` + name + `"
+  datasource_id   = "` + datasourceID + `"
+  identifier_type = "user"
+  query           = "select user_id, country from users"
+  description     = "Acceptance test dimension"
+}
+data "growthbook_dimension" "by_name" {
+  name = growthbook_dimension.test.name
+}
+`
+}
+
+func testAccDimensionConfigUpdate(name, datasourceID string) string {
+	return `
+resource "growthbook_dimension" "test" {
+  name            = "` + name + `"
+  datasource_id   = "` + datasourceID + `"
+  identifier_type = "user"
+  query           = "select user_id, region from users"
+  description     = "Updated dimension"
+}
+data "growthbook_dimension" "by_name" {
+  name = growthbook_dimension.test.name
+}
+`
+}
+
+func TestAccDimension_basic(t *testing.T) {
+	t.Parallel()
+
+	datasourceID := os.Getenv("GROWTHBOOK_TEST_DATASOURCE_ID")
+	if datasourceID == "" {
+		t.Skip("GROWTHBOOK_TEST_DATASOURCE_ID not set")
+	}
+
+	name := acctest.RandomWithPrefix("tf-acc-dimension-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDimensionConfig(name, datasourceID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_dimension.test", "name", name),
+					resource.TestCheckResourceAttr("data.growthbook_dimension.by_name", "query", "select user_id, country from users"),
+				),
+			},
+			{
+				Config: testAccDimensionConfigUpdate(name, datasourceID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_dimension.test", "description", "Updated dimension"),
+					resource.TestCheckResourceAttr("data.growthbook_dimension.by_name", "query", "select user_id, region from users"),
+				),
+			},
+		},
+	})
+}

--- a/internal/resource_environment.go
+++ b/internal/resource_environment.go
@@ -2,8 +2,8 @@ package internal
 
 import (
 	"context"
+	"errors"
 
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -119,7 +119,7 @@ func (r *environmentResource) Create(ctx context.Context, req resource.CreateReq
 	data.Description = types.StringValue(created.Description)
 	data.ToggleOnList = types.BoolValue(created.ToggleOnList)
 	data.DefaultState = types.BoolValue(created.DefaultState)
-	data.Projects = stringsToList(ctx, created.Projects)
+	data.Projects = stringsToList(created.Projects)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -133,6 +133,10 @@ func (r *environmentResource) Read(ctx context.Context, req resource.ReadRequest
 
 	env, err := r.client.FindEnvironmentByID(ctx, data.ID.ValueString())
 	if err != nil {
+		if errors.Is(err, growthbookapi.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Error reading environment", err.Error())
 		return
 	}
@@ -141,7 +145,7 @@ func (r *environmentResource) Read(ctx context.Context, req resource.ReadRequest
 	data.Description = types.StringValue(env.Description)
 	data.ToggleOnList = types.BoolValue(env.ToggleOnList)
 	data.DefaultState = types.BoolValue(env.DefaultState)
-	data.Projects = stringsToList(ctx, env.Projects)
+	data.Projects = stringsToList(env.Projects)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -197,15 +201,4 @@ func (r *environmentResource) Delete(ctx context.Context, req resource.DeleteReq
 
 func (r *environmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
-}
-
-// stringsToList converts a []string to a types.List of strings.
-// Since elements are always valid strings, this never returns an error.
-func stringsToList(_ context.Context, ss []string) types.List {
-	elems := make([]attr.Value, len(ss))
-	for i, s := range ss {
-		elems[i] = types.StringValue(s)
-	}
-	list, _ := types.ListValue(types.StringType, elems)
-	return list
 }

--- a/internal/resource_environment_test.go
+++ b/internal/resource_environment_test.go
@@ -47,7 +47,7 @@ func TestAccGrowthBookEnvironment_basic(t *testing.T) {
 	envName := acctest.RandomWithPrefix("tf-acc-env-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/resource_experiment.go
+++ b/internal/resource_experiment.go
@@ -1,0 +1,239 @@
+package internal
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-growthbook/internal/growthbookapi"
+)
+
+var _ resource.Resource = &experimentResource{}
+var _ resource.ResourceWithImportState = &experimentResource{}
+
+func newExperimentResource() resource.Resource {
+	return &experimentResource{}
+}
+
+type experimentResource struct {
+	client *growthbookapi.Client
+}
+
+type experimentModel struct {
+	ID                types.String `tfsdk:"id"`
+	Name              types.String `tfsdk:"name"`
+	TrackingKey       types.String `tfsdk:"tracking_key"`
+	Variations        types.String `tfsdk:"variations"`
+	Type              types.String `tfsdk:"type"`
+	Project           types.String `tfsdk:"project"`
+	Hypothesis        types.String `tfsdk:"hypothesis"`
+	Description       types.String `tfsdk:"description"`
+	Tags              types.List   `tfsdk:"tags"`
+	Owner             types.String `tfsdk:"owner"`
+	Archived          types.Bool   `tfsdk:"archived"`
+	Status            types.String `tfsdk:"status"`
+	AutoRefresh       types.Bool   `tfsdk:"auto_refresh"`
+	HashAttribute     types.String `tfsdk:"hash_attribute"`
+	FallbackAttribute types.String `tfsdk:"fallback_attribute"`
+	DatasourceID      types.String `tfsdk:"datasource_id"`
+	AssignmentQueryID types.String `tfsdk:"assignment_query_id"`
+	SegmentID         types.String `tfsdk:"segment_id"`
+	Metrics           types.List   `tfsdk:"metrics"`
+	SecondaryMetrics  types.List   `tfsdk:"secondary_metrics"`
+	GuardrailMetrics  types.List   `tfsdk:"guardrail_metrics"`
+	StatsEngine       types.String `tfsdk:"stats_engine"`
+	Phases            types.String `tfsdk:"phases"`
+	DateCreated       types.String `tfsdk:"date_created"`
+	DateUpdated       types.String `tfsdk:"date_updated"`
+}
+
+func (r *experimentResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_experiment"
+}
+
+func (r *experimentResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id":                  schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"name":                schema.StringAttribute{Required: true},
+			"tracking_key":        schema.StringAttribute{Required: true},
+			"variations":          schema.StringAttribute{Required: true, Validators: []validator.String{JSONString()}},
+			"type":                schema.StringAttribute{Optional: true, Computed: true},
+			"project":             schema.StringAttribute{Optional: true, Computed: true},
+			"hypothesis":          schema.StringAttribute{Optional: true, Computed: true},
+			"description":         schema.StringAttribute{Optional: true, Computed: true},
+			"tags":                schema.ListAttribute{ElementType: types.StringType, Optional: true, Computed: true},
+			"owner":               schema.StringAttribute{Optional: true, Computed: true},
+			"archived":            schema.BoolAttribute{Optional: true, Computed: true},
+			"status":              schema.StringAttribute{Optional: true, Computed: true},
+			"auto_refresh":        schema.BoolAttribute{Optional: true, Computed: true},
+			"hash_attribute":      schema.StringAttribute{Optional: true, Computed: true},
+			"fallback_attribute":  schema.StringAttribute{Optional: true, Computed: true},
+			"datasource_id":       schema.StringAttribute{Optional: true, Computed: true},
+			"assignment_query_id": schema.StringAttribute{Optional: true, Computed: true},
+			"segment_id":          schema.StringAttribute{Optional: true, Computed: true},
+			"metrics":             schema.ListAttribute{ElementType: types.StringType, Optional: true, Computed: true},
+			"secondary_metrics":   schema.ListAttribute{ElementType: types.StringType, Optional: true, Computed: true},
+			"guardrail_metrics":   schema.ListAttribute{ElementType: types.StringType, Optional: true, Computed: true},
+			"stats_engine":        schema.StringAttribute{Optional: true, Computed: true},
+			"phases":              schema.StringAttribute{Optional: true, Computed: true, Validators: []validator.String{JSONString()}},
+			"date_created":        schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"date_updated":        schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (r *experimentResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*growthbookapi.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *growthbookapi.Client")
+		return
+	}
+	r.client = client
+}
+
+func experimentFromModel(data experimentModel) *growthbookapi.Experiment {
+	return &growthbookapi.Experiment{
+		Name:              data.Name.ValueString(),
+		TrackingKey:       data.TrackingKey.ValueString(),
+		Variations:        stringToRawJSON(data.Variations.ValueString()),
+		Type:              data.Type.ValueString(),
+		Project:           data.Project.ValueString(),
+		Hypothesis:        data.Hypothesis.ValueString(),
+		Description:       data.Description.ValueString(),
+		Tags:              listToStrings(data.Tags),
+		Owner:             data.Owner.ValueString(),
+		Archived:          data.Archived.ValueBool(),
+		Status:            data.Status.ValueString(),
+		AutoRefresh:       data.AutoRefresh.ValueBool(),
+		HashAttribute:     data.HashAttribute.ValueString(),
+		FallbackAttribute: data.FallbackAttribute.ValueString(),
+		DatasourceID:      data.DatasourceID.ValueString(),
+		AssignmentQueryID: data.AssignmentQueryID.ValueString(),
+		SegmentID:         data.SegmentID.ValueString(),
+		Metrics:           listToStrings(data.Metrics),
+		SecondaryMetrics:  listToStrings(data.SecondaryMetrics),
+		GuardrailMetrics:  listToStrings(data.GuardrailMetrics),
+		StatsEngine:       data.StatsEngine.ValueString(),
+		Phases:            stringToRawJSON(data.Phases.ValueString()),
+	}
+}
+
+func experimentModelFromAPI(data *experimentModel, item *growthbookapi.Experiment) {
+	data.ID = types.StringValue(item.ID)
+	data.Name = types.StringValue(item.Name)
+	data.TrackingKey = types.StringValue(item.TrackingKey)
+	data.Variations = types.StringValue(rawJSONToString(item.Variations))
+	data.Type = types.StringValue(item.Type)
+	data.Project = types.StringValue(item.Project)
+	data.Hypothesis = types.StringValue(item.Hypothesis)
+	data.Description = types.StringValue(item.Description)
+	data.Tags = stringsToList(item.Tags)
+	data.Owner = types.StringValue(item.Owner)
+	data.Archived = types.BoolValue(item.Archived)
+	data.Status = types.StringValue(item.Status)
+	data.AutoRefresh = types.BoolValue(item.AutoRefresh)
+	data.HashAttribute = types.StringValue(item.HashAttribute)
+	data.FallbackAttribute = types.StringValue(item.FallbackAttribute)
+	data.DatasourceID = types.StringValue(item.DatasourceID)
+	data.AssignmentQueryID = types.StringValue(item.AssignmentQueryID)
+	data.SegmentID = types.StringValue(item.SegmentID)
+	data.Metrics = stringsToList(item.Metrics)
+	data.SecondaryMetrics = stringsToList(item.SecondaryMetrics)
+	data.GuardrailMetrics = stringsToList(item.GuardrailMetrics)
+	data.StatsEngine = types.StringValue(item.StatsEngine)
+	data.Phases = types.StringValue(rawJSONToString(item.Phases))
+	data.DateCreated = types.StringValue(item.DateCreated)
+	data.DateUpdated = types.StringValue(item.DateUpdated)
+}
+
+func (r *experimentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data experimentModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.CreateExperiment(ctx, experimentFromModel(data))
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating experiment", err.Error())
+		return
+	}
+
+	experimentModelFromAPI(&data, item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *experimentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data experimentModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.GetExperiment(ctx, data.ID.ValueString())
+	if err != nil {
+		if errors.Is(err, growthbookapi.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading experiment", err.Error())
+		return
+	}
+
+	experimentModelFromAPI(&data, item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *experimentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data experimentModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state experimentModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.UpdateExperiment(ctx, state.ID.ValueString(), experimentFromModel(data))
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating experiment", err.Error())
+		return
+	}
+
+	experimentModelFromAPI(&data, item)
+	data.ID = state.ID
+	if data.DateCreated.ValueString() == "" {
+		data.DateCreated = state.DateCreated
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *experimentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data experimentModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.DeleteExperiment(ctx, data.ID.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error deleting experiment", err.Error())
+	}
+}
+
+func (r *experimentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/resource_experiment_test.go
+++ b/internal/resource_experiment_test.go
@@ -1,0 +1,72 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func testAccExperimentConfig(name string) string {
+	return `
+resource "growthbook_experiment" "test" {
+  name         = "` + name + `"
+  tracking_key = "` + name + `-tracking"
+  description  = "Acceptance test experiment"
+  variations   = jsonencode([
+    { key = "0", name = "Control" },
+    { key = "1", name = "Variant" }
+  ])
+}
+data "growthbook_experiment" "by_name" {
+  name = growthbook_experiment.test.name
+}
+`
+}
+
+func testAccExperimentConfigUpdate(name string) string {
+	return `
+resource "growthbook_experiment" "test" {
+  name         = "` + name + `"
+  tracking_key = "` + name + `-tracking"
+  description  = "Updated experiment"
+  hypothesis   = "Variant increases conversions"
+  variations   = jsonencode([
+    { key = "0", name = "Control" },
+    { key = "1", name = "Variant" }
+  ])
+  phases = jsonencode([{ name = "Phase 1" }])
+}
+data "growthbook_experiment" "by_name" {
+  name = growthbook_experiment.test.name
+}
+`
+}
+
+func TestAccExperiment_basic(t *testing.T) {
+	t.Parallel()
+
+	name := acctest.RandomWithPrefix("tf-acc-experiment-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExperimentConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_experiment.test", "name", name),
+					resource.TestCheckResourceAttr("data.growthbook_experiment.by_name", "tracking_key", name+"-tracking"),
+				),
+			},
+			{
+				Config: testAccExperimentConfigUpdate(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_experiment.test", "description", "Updated experiment"),
+					resource.TestCheckResourceAttr(
+						"data.growthbook_experiment.by_name", "hypothesis", "Variant increases conversions"),
+				),
+			},
+		},
+	})
+}

--- a/internal/resource_fact_metric.go
+++ b/internal/resource_fact_metric.go
@@ -1,0 +1,239 @@
+package internal
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-growthbook/internal/growthbookapi"
+)
+
+var _ resource.Resource = &factMetricResource{}
+var _ resource.ResourceWithImportState = &factMetricResource{}
+
+func newFactMetricResource() resource.Resource {
+	return &factMetricResource{}
+}
+
+type factMetricResource struct {
+	client *growthbookapi.Client
+}
+
+type factMetricModel struct {
+	ID                           types.String  `tfsdk:"id"`
+	Name                         types.String  `tfsdk:"name"`
+	MetricType                   types.String  `tfsdk:"metric_type"`
+	Numerator                    types.String  `tfsdk:"numerator"`
+	Datasource                   types.String  `tfsdk:"datasource"`
+	Description                  types.String  `tfsdk:"description"`
+	Owner                        types.String  `tfsdk:"owner"`
+	Projects                     types.List    `tfsdk:"projects"`
+	Tags                         types.List    `tfsdk:"tags"`
+	Denominator                  types.String  `tfsdk:"denominator"`
+	Inverse                      types.Bool    `tfsdk:"inverse"`
+	CappingSettings              types.String  `tfsdk:"capping_settings"`
+	WindowSettings               types.String  `tfsdk:"window_settings"`
+	PriorSettings                types.String  `tfsdk:"prior_settings"`
+	RegressionAdjustmentSettings types.String  `tfsdk:"regression_adjustment_settings"`
+	RiskThresholdSuccess         types.Float64 `tfsdk:"risk_threshold_success"`
+	RiskThresholdDanger          types.Float64 `tfsdk:"risk_threshold_danger"`
+	MinPercentChange             types.Float64 `tfsdk:"min_percent_change"`
+	MaxPercentChange             types.Float64 `tfsdk:"max_percent_change"`
+	MinSampleSize                types.Float64 `tfsdk:"min_sample_size"`
+	TargetMDE                    types.Float64 `tfsdk:"target_mde"`
+	ManagedBy                    types.String  `tfsdk:"managed_by"`
+	Archived                     types.Bool    `tfsdk:"archived"`
+	DateCreated                  types.String  `tfsdk:"date_created"`
+	DateUpdated                  types.String  `tfsdk:"date_updated"`
+}
+
+func (r *factMetricResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_fact_metric"
+}
+
+func (r *factMetricResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id":                             schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"name":                           schema.StringAttribute{Required: true},
+			"metric_type":                    schema.StringAttribute{Required: true},
+			"numerator":                      schema.StringAttribute{Required: true, Validators: []validator.String{JSONString()}},
+			"datasource":                     schema.StringAttribute{Optional: true, Computed: true},
+			"description":                    schema.StringAttribute{Optional: true, Computed: true},
+			"owner":                          schema.StringAttribute{Optional: true, Computed: true},
+			"projects":                       schema.ListAttribute{ElementType: types.StringType, Optional: true, Computed: true},
+			"tags":                           schema.ListAttribute{ElementType: types.StringType, Optional: true, Computed: true},
+			"denominator":                    schema.StringAttribute{Optional: true, Computed: true, Validators: []validator.String{JSONString()}},
+			"inverse":                        schema.BoolAttribute{Optional: true, Computed: true},
+			"capping_settings":               schema.StringAttribute{Optional: true, Computed: true, Validators: []validator.String{JSONString()}},
+			"window_settings":                schema.StringAttribute{Optional: true, Computed: true, Validators: []validator.String{JSONString()}},
+			"prior_settings":                 schema.StringAttribute{Optional: true, Computed: true, Validators: []validator.String{JSONString()}},
+			"regression_adjustment_settings": schema.StringAttribute{Optional: true, Computed: true, Validators: []validator.String{JSONString()}},
+			"risk_threshold_success":         schema.Float64Attribute{Optional: true, Computed: true},
+			"risk_threshold_danger":          schema.Float64Attribute{Optional: true, Computed: true},
+			"min_percent_change":             schema.Float64Attribute{Optional: true, Computed: true},
+			"max_percent_change":             schema.Float64Attribute{Optional: true, Computed: true},
+			"min_sample_size":                schema.Float64Attribute{Optional: true, Computed: true},
+			"target_mde":                     schema.Float64Attribute{Optional: true, Computed: true},
+			"managed_by":                     schema.StringAttribute{Optional: true, Computed: true},
+			"archived":                       schema.BoolAttribute{Optional: true, Computed: true},
+			"date_created":                   schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"date_updated":                   schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (r *factMetricResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*growthbookapi.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *growthbookapi.Client")
+		return
+	}
+	r.client = client
+}
+
+func factMetricFromModel(data factMetricModel) *growthbookapi.FactMetric {
+	return &growthbookapi.FactMetric{
+		Name:                         data.Name.ValueString(),
+		MetricType:                   data.MetricType.ValueString(),
+		Numerator:                    stringToRawJSON(data.Numerator.ValueString()),
+		Datasource:                   data.Datasource.ValueString(),
+		Description:                  data.Description.ValueString(),
+		Owner:                        data.Owner.ValueString(),
+		Projects:                     listToStrings(data.Projects),
+		Tags:                         listToStrings(data.Tags),
+		Denominator:                  stringToRawJSON(data.Denominator.ValueString()),
+		Inverse:                      data.Inverse.ValueBool(),
+		CappingSettings:              stringToRawJSON(data.CappingSettings.ValueString()),
+		WindowSettings:               stringToRawJSON(data.WindowSettings.ValueString()),
+		PriorSettings:                stringToRawJSON(data.PriorSettings.ValueString()),
+		RegressionAdjustmentSettings: stringToRawJSON(data.RegressionAdjustmentSettings.ValueString()),
+		RiskThresholdSuccess:         float64PointerValue(data.RiskThresholdSuccess),
+		RiskThresholdDanger:          float64PointerValue(data.RiskThresholdDanger),
+		MinPercentChange:             float64PointerValue(data.MinPercentChange),
+		MaxPercentChange:             float64PointerValue(data.MaxPercentChange),
+		MinSampleSize:                float64PointerValue(data.MinSampleSize),
+		TargetMDE:                    float64PointerValue(data.TargetMDE),
+		ManagedBy:                    data.ManagedBy.ValueString(),
+		Archived:                     data.Archived.ValueBool(),
+	}
+}
+
+func factMetricModelFromAPI(data *factMetricModel, item *growthbookapi.FactMetric) {
+	data.ID = types.StringValue(item.ID)
+	data.Name = types.StringValue(item.Name)
+	data.MetricType = types.StringValue(item.MetricType)
+	data.Numerator = types.StringValue(rawJSONToString(item.Numerator))
+	data.Datasource = types.StringValue(item.Datasource)
+	data.Description = types.StringValue(item.Description)
+	data.Owner = types.StringValue(item.Owner)
+	data.Projects = stringsToList(item.Projects)
+	data.Tags = stringsToList(item.Tags)
+	data.Denominator = types.StringValue(rawJSONToString(item.Denominator))
+	data.Inverse = types.BoolValue(item.Inverse)
+	data.CappingSettings = types.StringValue(rawJSONToString(item.CappingSettings))
+	data.WindowSettings = types.StringValue(rawJSONToString(item.WindowSettings))
+	data.PriorSettings = types.StringValue(rawJSONToString(item.PriorSettings))
+	data.RegressionAdjustmentSettings = types.StringValue(rawJSONToString(item.RegressionAdjustmentSettings))
+	data.RiskThresholdSuccess = float64ValuePointer(item.RiskThresholdSuccess)
+	data.RiskThresholdDanger = float64ValuePointer(item.RiskThresholdDanger)
+	data.MinPercentChange = float64ValuePointer(item.MinPercentChange)
+	data.MaxPercentChange = float64ValuePointer(item.MaxPercentChange)
+	data.MinSampleSize = float64ValuePointer(item.MinSampleSize)
+	data.TargetMDE = float64ValuePointer(item.TargetMDE)
+	data.ManagedBy = types.StringValue(item.ManagedBy)
+	data.Archived = types.BoolValue(item.Archived)
+	data.DateCreated = types.StringValue(item.DateCreated)
+	data.DateUpdated = types.StringValue(item.DateUpdated)
+}
+
+func (r *factMetricResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data factMetricModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.CreateFactMetric(ctx, factMetricFromModel(data))
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating fact metric", err.Error())
+		return
+	}
+
+	factMetricModelFromAPI(&data, item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *factMetricResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data factMetricModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.GetFactMetric(ctx, data.ID.ValueString())
+	if err != nil {
+		if errors.Is(err, growthbookapi.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading fact metric", err.Error())
+		return
+	}
+
+	factMetricModelFromAPI(&data, item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *factMetricResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data factMetricModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state factMetricModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.UpdateFactMetric(ctx, state.ID.ValueString(), factMetricFromModel(data))
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating fact metric", err.Error())
+		return
+	}
+
+	factMetricModelFromAPI(&data, item)
+	data.ID = state.ID
+	if data.DateCreated.ValueString() == "" {
+		data.DateCreated = state.DateCreated
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *factMetricResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data factMetricModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.DeleteFactMetric(ctx, data.ID.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error deleting fact metric", err.Error())
+	}
+}
+
+func (r *factMetricResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/resource_fact_metric_test.go
+++ b/internal/resource_fact_metric_test.go
@@ -1,0 +1,80 @@
+package internal_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func testAccFactMetricConfig(name, datasourceID, factTableID string) string {
+	return `
+resource "growthbook_fact_metric" "test" {
+  name        = "` + name + `"
+  metric_type = "proportion"
+  datasource  = "` + datasourceID + `"
+  numerator   = jsonencode({ factTableId = "` + factTableID + `", column = "" })
+  description = "Acceptance test fact metric"
+}
+data "growthbook_fact_metric" "by_name" {
+  name = growthbook_fact_metric.test.name
+}
+`
+}
+
+func testAccFactMetricConfigUpdate(name, datasourceID, factTableID string) string {
+	return `
+resource "growthbook_fact_metric" "test" {
+  name        = "` + name + `"
+  metric_type = "proportion"
+  datasource  = "` + datasourceID + `"
+  numerator   = jsonencode({ factTableId = "` + factTableID + `", column = "" })
+  denominator = jsonencode({ factTableId = "` + factTableID + `", column = "$$distinctUsers" })
+  inverse     = true
+  description = "Updated fact metric"
+}
+data "growthbook_fact_metric" "by_name" {
+  name = growthbook_fact_metric.test.name
+}
+`
+}
+
+func TestAccFactMetric_basic(t *testing.T) {
+	t.Parallel()
+
+	datasourceID := os.Getenv("GROWTHBOOK_TEST_DATASOURCE_ID")
+	if datasourceID == "" {
+		t.Skip("GROWTHBOOK_TEST_DATASOURCE_ID not set")
+	}
+
+	factTableID := os.Getenv("GROWTHBOOK_TEST_FACT_TABLE_ID")
+	if factTableID == "" {
+		t.Skip("GROWTHBOOK_TEST_FACT_TABLE_ID not set")
+	}
+
+	name := acctest.RandomWithPrefix("tf-acc-fact-metric-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFactMetricConfig(name, datasourceID, factTableID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_fact_metric.test", "name", name),
+					resource.TestCheckResourceAttr("growthbook_fact_metric.test", "metric_type", "proportion"),
+					resource.TestCheckResourceAttr(
+						"data.growthbook_fact_metric.by_name", "description", "Acceptance test fact metric"),
+				),
+			},
+			{
+				Config: testAccFactMetricConfigUpdate(name, datasourceID, factTableID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_fact_metric.test", "inverse", "true"),
+					resource.TestCheckResourceAttr("data.growthbook_fact_metric.by_name", "description", "Updated fact metric"),
+				),
+			},
+		},
+	})
+}

--- a/internal/resource_fact_table.go
+++ b/internal/resource_fact_table.go
@@ -1,0 +1,194 @@
+package internal
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-growthbook/internal/growthbookapi"
+)
+
+var _ resource.Resource = &factTableResource{}
+var _ resource.ResourceWithImportState = &factTableResource{}
+
+func newFactTableResource() resource.Resource {
+	return &factTableResource{}
+}
+
+type factTableResource struct {
+	client *growthbookapi.Client
+}
+
+type factTableModel struct {
+	ID          types.String `tfsdk:"id"`
+	Name        types.String `tfsdk:"name"`
+	Datasource  types.String `tfsdk:"datasource"`
+	UserIDTypes types.List   `tfsdk:"user_id_types"`
+	SQL         types.String `tfsdk:"sql"`
+	Description types.String `tfsdk:"description"`
+	Owner       types.String `tfsdk:"owner"`
+	Projects    types.List   `tfsdk:"projects"`
+	Tags        types.List   `tfsdk:"tags"`
+	EventName   types.String `tfsdk:"event_name"`
+	ManagedBy   types.String `tfsdk:"managed_by"`
+	Archived    types.Bool   `tfsdk:"archived"`
+	DateCreated types.String `tfsdk:"date_created"`
+	DateUpdated types.String `tfsdk:"date_updated"`
+}
+
+func (r *factTableResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_fact_table"
+}
+
+func (r *factTableResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id":            schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"name":          schema.StringAttribute{Required: true},
+			"datasource":    schema.StringAttribute{Required: true},
+			"user_id_types": schema.ListAttribute{ElementType: types.StringType, Required: true},
+			"sql":           schema.StringAttribute{Required: true},
+			"description":   schema.StringAttribute{Optional: true, Computed: true},
+			"owner":         schema.StringAttribute{Optional: true, Computed: true},
+			"projects":      schema.ListAttribute{ElementType: types.StringType, Optional: true, Computed: true},
+			"tags":          schema.ListAttribute{ElementType: types.StringType, Optional: true, Computed: true},
+			"event_name":    schema.StringAttribute{Optional: true, Computed: true},
+			"managed_by":    schema.StringAttribute{Optional: true, Computed: true},
+			"archived":      schema.BoolAttribute{Optional: true, Computed: true},
+			"date_created":  schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"date_updated":  schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (r *factTableResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*growthbookapi.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *growthbookapi.Client")
+		return
+	}
+	r.client = client
+}
+
+func factTableFromModel(data factTableModel) *growthbookapi.FactTable {
+	return &growthbookapi.FactTable{
+		Name:        data.Name.ValueString(),
+		Datasource:  data.Datasource.ValueString(),
+		UserIDTypes: listToStrings(data.UserIDTypes),
+		SQL:         data.SQL.ValueString(),
+		Description: data.Description.ValueString(),
+		Owner:       data.Owner.ValueString(),
+		Projects:    listToStrings(data.Projects),
+		Tags:        listToStrings(data.Tags),
+		EventName:   data.EventName.ValueString(),
+		ManagedBy:   data.ManagedBy.ValueString(),
+		Archived:    data.Archived.ValueBool(),
+	}
+}
+
+func factTableModelFromAPI(data *factTableModel, item *growthbookapi.FactTable) {
+	data.ID = types.StringValue(item.ID)
+	data.Name = types.StringValue(item.Name)
+	data.Datasource = types.StringValue(item.Datasource)
+	data.UserIDTypes = stringsToList(item.UserIDTypes)
+	data.SQL = types.StringValue(item.SQL)
+	data.Description = types.StringValue(item.Description)
+	data.Owner = types.StringValue(item.Owner)
+	data.Projects = stringsToList(item.Projects)
+	data.Tags = stringsToList(item.Tags)
+	data.EventName = types.StringValue(item.EventName)
+	data.ManagedBy = types.StringValue(item.ManagedBy)
+	data.Archived = types.BoolValue(item.Archived)
+	data.DateCreated = types.StringValue(item.DateCreated)
+	data.DateUpdated = types.StringValue(item.DateUpdated)
+}
+
+func (r *factTableResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data factTableModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.CreateFactTable(ctx, factTableFromModel(data))
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating fact table", err.Error())
+		return
+	}
+
+	factTableModelFromAPI(&data, item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *factTableResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data factTableModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.GetFactTable(ctx, data.ID.ValueString())
+	if err != nil {
+		if errors.Is(err, growthbookapi.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading fact table", err.Error())
+		return
+	}
+
+	factTableModelFromAPI(&data, item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *factTableResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data factTableModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state factTableModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.UpdateFactTable(ctx, state.ID.ValueString(), factTableFromModel(data))
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating fact table", err.Error())
+		return
+	}
+
+	factTableModelFromAPI(&data, item)
+	data.ID = state.ID
+	if data.DateCreated.ValueString() == "" {
+		data.DateCreated = state.DateCreated
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *factTableResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data factTableModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.DeleteFactTable(ctx, data.ID.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error deleting fact table", err.Error())
+	}
+}
+
+func (r *factTableResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/resource_fact_table_test.go
+++ b/internal/resource_fact_table_test.go
@@ -1,0 +1,71 @@
+package internal_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func testAccFactTableConfig(name, datasourceID string) string {
+	return `
+resource "growthbook_fact_table" "test" {
+  name          = "` + name + `"
+  datasource    = "` + datasourceID + `"
+  user_id_types = ["user"]
+  sql           = "select user_id from events"
+  description   = "Acceptance test fact table"
+}
+data "growthbook_fact_table" "by_name" {
+  name = growthbook_fact_table.test.name
+}
+`
+}
+
+func testAccFactTableConfigUpdate(name, datasourceID string) string {
+	return `
+resource "growthbook_fact_table" "test" {
+  name          = "` + name + `"
+  datasource    = "` + datasourceID + `"
+  user_id_types = ["user", "anonymous"]
+  sql           = "select user_id, anonymous_id from events"
+  description   = "Updated fact table"
+}
+data "growthbook_fact_table" "by_name" {
+  name = growthbook_fact_table.test.name
+}
+`
+}
+
+func TestAccFactTable_basic(t *testing.T) {
+	t.Parallel()
+
+	datasourceID := os.Getenv("GROWTHBOOK_TEST_DATASOURCE_ID")
+	if datasourceID == "" {
+		t.Skip("GROWTHBOOK_TEST_DATASOURCE_ID not set")
+	}
+
+	name := acctest.RandomWithPrefix("tf-acc-fact-table-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFactTableConfig(name, datasourceID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_fact_table.test", "name", name),
+					resource.TestCheckResourceAttr("data.growthbook_fact_table.by_name", "datasource", datasourceID),
+				),
+			},
+			{
+				Config: testAccFactTableConfigUpdate(name, datasourceID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_fact_table.test", "description", "Updated fact table"),
+					resource.TestCheckResourceAttr("data.growthbook_fact_table.by_name", "user_id_types.#", "2"),
+				),
+			},
+		},
+	})
+}

--- a/internal/resource_feature.go
+++ b/internal/resource_feature.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -350,6 +351,10 @@ func (r *featureResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	feature, err := r.client.GetFeature(ctx, data.ID.ValueString())
 	if err != nil {
+		if errors.Is(err, growthbookapi.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Error reading feature", err.Error())
 		return
 	}
@@ -447,8 +452,8 @@ func featureModelFromAPI(ctx context.Context, m *featureModel, f *growthbookapi.
 	m.Project = types.StringValue(f.Project)
 	m.ValueType = types.StringValue(f.ValueType)
 	m.DefaultValue = types.StringValue(f.DefaultValue)
-	m.Tags = stringsToList(ctx, f.Tags)
-	m.Prerequisites = stringsToList(ctx, f.Prerequisites)
+	m.Tags = stringsToList(f.Tags)
+	m.Prerequisites = stringsToList(f.Prerequisites)
 
 	envsMap := envsFromAPI(f.Environments)
 	var d diag.Diagnostics

--- a/internal/resource_feature.go
+++ b/internal/resource_feature.go
@@ -39,17 +39,25 @@ type featureEnvironmentModel struct {
 
 // featureRuleModel maps a single targeting rule (force / rollout / experiment-ref).
 type featureRuleModel struct {
-	ID            types.String            `tfsdk:"id"`
-	Type          types.String            `tfsdk:"type"`
-	Enabled       types.Bool              `tfsdk:"enabled"`
-	Description   types.String            `tfsdk:"description"`
-	Condition     types.String            `tfsdk:"condition"`
-	Value         types.String            `tfsdk:"value"`
-	Coverage      types.Float64           `tfsdk:"coverage"`
-	HashAttribute types.String            `tfsdk:"hash_attribute"`
-	ExperimentID  types.String            `tfsdk:"experiment_id"`
-	Variations    []featureVariationModel `tfsdk:"variations"`
-	Prerequisites []featurePrereqModel    `tfsdk:"prerequisites"`
+	ID                  types.String                      `tfsdk:"id"`
+	Type                types.String                      `tfsdk:"type"`
+	Enabled             types.Bool                        `tfsdk:"enabled"`
+	Description         types.String                      `tfsdk:"description"`
+	Condition           types.String                      `tfsdk:"condition"`
+	Value               types.String                      `tfsdk:"value"`
+	Coverage            types.Float64                     `tfsdk:"coverage"`
+	HashAttribute       types.String                      `tfsdk:"hash_attribute"`
+	FallbackAttribute   types.String                      `tfsdk:"fallback_attribute"`
+	HashVersion         types.Int64                       `tfsdk:"hash_version"`
+	Seed                types.String                      `tfsdk:"seed"`
+	TrackingKey         types.String                      `tfsdk:"tracking_key"`
+	ScheduleType        types.String                      `tfsdk:"schedule_type"`
+	Namespace           []featureNamespaceModel           `tfsdk:"namespace"`
+	ScheduleRules       []featureScheduleRuleModel        `tfsdk:"schedule_rules"`
+	ExperimentID        types.String                      `tfsdk:"experiment_id"`
+	Variations          []featureVariationModel           `tfsdk:"variations"`
+	Prerequisites       []featurePrereqModel              `tfsdk:"prerequisites"`
+	SavedGroupTargeting []featureSavedGroupTargetingModel `tfsdk:"saved_group_targeting"`
 }
 
 // featureVariationModel maps a single experiment-ref variation.
@@ -62,6 +70,26 @@ type featureVariationModel struct {
 type featurePrereqModel struct {
 	ID        types.String `tfsdk:"id"`
 	Condition types.String `tfsdk:"condition"`
+}
+
+// featureSavedGroupTargetingModel maps a saved group targeting entry on a rule.
+type featureSavedGroupTargetingModel struct {
+	MatchType   types.String `tfsdk:"match_type"`
+	SavedGroups types.List   `tfsdk:"saved_groups"`
+}
+
+// featureNamespaceModel maps a traffic namespace on a rule.
+type featureNamespaceModel struct {
+	Enabled    types.Bool    `tfsdk:"enabled"`
+	Name       types.String  `tfsdk:"name"`
+	RangeStart types.Float64 `tfsdk:"range_start"`
+	RangeEnd   types.Float64 `tfsdk:"range_end"`
+}
+
+// featureScheduleRuleModel maps a time-based schedule entry.
+type featureScheduleRuleModel struct {
+	Timestamp types.String `tfsdk:"timestamp"`
+	Enabled   types.Bool   `tfsdk:"enabled"`
 }
 
 type featureModel struct {
@@ -96,17 +124,48 @@ func featureVariationObjectType() types.ObjectType {
 
 func featureRuleObjectType() types.ObjectType {
 	return types.ObjectType{AttrTypes: map[string]attr.Type{
-		"id":             types.StringType,
-		"type":           types.StringType,
-		"enabled":        types.BoolType,
-		"description":    types.StringType,
-		"condition":      types.StringType,
-		"value":          types.StringType,
-		"coverage":       types.Float64Type,
-		"hash_attribute": types.StringType,
-		"experiment_id":  types.StringType,
-		"variations":     types.ListType{ElemType: featureVariationObjectType()},
-		"prerequisites":  types.ListType{ElemType: featurePrereqObjectType()},
+		"id":                    types.StringType,
+		"type":                  types.StringType,
+		"enabled":               types.BoolType,
+		"description":           types.StringType,
+		"condition":             types.StringType,
+		"value":                 types.StringType,
+		"coverage":              types.Float64Type,
+		"hash_attribute":        types.StringType,
+		"fallback_attribute":    types.StringType,
+		"hash_version":          types.Int64Type,
+		"seed":                  types.StringType,
+		"tracking_key":          types.StringType,
+		"schedule_type":         types.StringType,
+		"namespace":             types.ListType{ElemType: featureNamespaceObjectType()},
+		"schedule_rules":        types.ListType{ElemType: featureScheduleRuleObjectType()},
+		"experiment_id":         types.StringType,
+		"variations":            types.ListType{ElemType: featureVariationObjectType()},
+		"prerequisites":         types.ListType{ElemType: featurePrereqObjectType()},
+		"saved_group_targeting": types.ListType{ElemType: featureSavedGroupTargetingObjectType()},
+	}}
+}
+
+func featureSavedGroupTargetingObjectType() types.ObjectType {
+	return types.ObjectType{AttrTypes: map[string]attr.Type{
+		"match_type":   types.StringType,
+		"saved_groups": types.ListType{ElemType: types.StringType},
+	}}
+}
+
+func featureNamespaceObjectType() types.ObjectType {
+	return types.ObjectType{AttrTypes: map[string]attr.Type{
+		"enabled":     types.BoolType,
+		"name":        types.StringType,
+		"range_start": types.Float64Type,
+		"range_end":   types.Float64Type,
+	}}
+}
+
+func featureScheduleRuleObjectType() types.ObjectType {
+	return types.ObjectType{AttrTypes: map[string]attr.Type{
+		"timestamp": types.StringType,
+		"enabled":   types.BoolType,
 	}}
 }
 
@@ -171,6 +230,79 @@ func featureEnvironmentSchemaAttr() schema.MapNestedAttribute {
 								Computed: true,
 								Default:  stringdefault.StaticString(""),
 							},
+							"fallback_attribute": schema.StringAttribute{
+								Optional:    true,
+								Computed:    true,
+								Default:     stringdefault.StaticString(""),
+								Description: "Fallback attribute for sticky bucketing.",
+							},
+							"hash_version": schema.Int64Attribute{
+								Optional:    true,
+								Computed:    true,
+								Description: "Hash version (1 or 2).",
+							},
+							"seed": schema.StringAttribute{
+								Optional:    true,
+								Computed:    true,
+								Default:     stringdefault.StaticString(""),
+								Description: "Random seed for hashing.",
+							},
+							"tracking_key": schema.StringAttribute{
+								Optional:    true,
+								Computed:    true,
+								Default:     stringdefault.StaticString(""),
+								Description: "Tracking key for experiment analytics.",
+							},
+							"schedule_type": schema.StringAttribute{
+								Optional:    true,
+								Computed:    true,
+								Default:     stringdefault.StaticString(""),
+								Description: "Schedule type: none, schedule, or ramp.",
+							},
+							"namespace": schema.ListNestedAttribute{
+								Optional:    true,
+								Computed:    true,
+								Description: "Traffic namespace for the rule.",
+								NestedObject: schema.NestedAttributeObject{
+									Attributes: map[string]schema.Attribute{
+										"enabled": schema.BoolAttribute{
+											Required: true,
+										},
+										"name": schema.StringAttribute{
+											Required:    true,
+											Description: "Namespace identifier.",
+										},
+										"range_start": schema.Float64Attribute{
+											Required:    true,
+											Description: "Start of the namespace range (0-1).",
+										},
+										"range_end": schema.Float64Attribute{
+											Required:    true,
+											Description: "End of the namespace range (0-1).",
+										},
+									},
+								},
+								Default: listdefault.StaticValue(types.ListValueMust(featureNamespaceObjectType(), []attr.Value{})),
+							},
+							"schedule_rules": schema.ListNestedAttribute{
+								Optional:    true,
+								Computed:    true,
+								Description: "Time-based schedule rules for enabling/disabling.",
+								NestedObject: schema.NestedAttributeObject{
+									Attributes: map[string]schema.Attribute{
+										"timestamp": schema.StringAttribute{
+											Optional:    true,
+											Computed:    true,
+											Description: "ISO timestamp for the schedule event.",
+										},
+										"enabled": schema.BoolAttribute{
+											Required:    true,
+											Description: "Whether the rule is enabled at this time.",
+										},
+									},
+								},
+								Default: listdefault.StaticValue(types.ListValueMust(featureScheduleRuleObjectType(), []attr.Value{})),
+							},
 							"experiment_id": schema.StringAttribute{
 								Optional: true,
 								Computed: true,
@@ -211,6 +343,24 @@ func featureEnvironmentSchemaAttr() schema.MapNestedAttribute {
 									"id":        types.StringType,
 									"condition": types.StringType,
 								}}, []attr.Value{})),
+							},
+							"saved_group_targeting": schema.ListNestedAttribute{
+								Optional: true,
+								Computed: true,
+								NestedObject: schema.NestedAttributeObject{
+									Attributes: map[string]schema.Attribute{
+										"match_type": schema.StringAttribute{
+											Required:    true,
+											Description: "How to match saved groups: all, none, or any.",
+										},
+										"saved_groups": schema.ListAttribute{
+											ElementType: types.StringType,
+											Required:    true,
+											Description: "List of saved group IDs to target.",
+										},
+									},
+								},
+								Default: listdefault.StaticValue(types.ListValueMust(featureSavedGroupTargetingObjectType(), []attr.Value{})),
 							},
 						},
 					},
@@ -483,21 +633,33 @@ func rulesFromAPI(rules []growthbookapi.FeatureRule) []featureRuleModel {
 	out := make([]featureRuleModel, len(rules))
 	for i, r := range rules {
 		rm := featureRuleModel{
-			ID:            types.StringValue(r.ID),
-			Type:          types.StringValue(r.Type),
-			Enabled:       types.BoolValue(r.Enabled),
-			Description:   types.StringValue(r.Description),
-			Condition:     types.StringValue(r.Condition),
-			Value:         types.StringValue(r.Value),
-			HashAttribute: types.StringValue(r.HashAttribute),
-			ExperimentID:  types.StringValue(r.ExperimentID),
-			Variations:    variationsFromAPI(r.Variations),
-			Prerequisites: rulePrereqsFromAPI(r.Prerequisites),
+			ID:                  types.StringValue(r.ID),
+			Type:                types.StringValue(r.Type),
+			Enabled:             types.BoolValue(r.Enabled),
+			Description:         types.StringValue(r.Description),
+			Condition:           types.StringValue(r.Condition),
+			Value:               types.StringValue(r.Value),
+			HashAttribute:       types.StringValue(r.HashAttribute),
+			FallbackAttribute:   types.StringValue(r.FallbackAttribute),
+			Seed:                types.StringValue(r.Seed),
+			TrackingKey:         types.StringValue(r.TrackingKey),
+			ScheduleType:        types.StringValue(r.ScheduleType),
+			ExperimentID:        types.StringValue(r.ExperimentID),
+			Variations:          variationsFromAPI(r.Variations),
+			Prerequisites:       rulePrereqsFromAPI(r.Prerequisites),
+			SavedGroupTargeting: savedGroupTargetingFromAPI(r.SavedGroupTargeting),
+			Namespace:           namespaceFromAPI(r.Namespace),
+			ScheduleRules:       scheduleRulesFromAPI(r.ScheduleRules),
 		}
 		if r.Coverage != nil {
 			rm.Coverage = types.Float64Value(*r.Coverage)
 		} else {
 			rm.Coverage = types.Float64Null()
+		}
+		if r.HashVersion != nil {
+			rm.HashVersion = types.Int64Value(int64(*r.HashVersion))
+		} else {
+			rm.HashVersion = types.Int64Null()
 		}
 		out[i] = rm
 	}
@@ -526,6 +688,17 @@ func rulePrereqsFromAPI(prereqs []growthbookapi.FeaturePrerequisite) []featurePr
 	return out
 }
 
+func savedGroupTargetingFromAPI(sgt []growthbookapi.FeatureSavedGroupTargeting) []featureSavedGroupTargetingModel {
+	out := make([]featureSavedGroupTargetingModel, len(sgt))
+	for i, s := range sgt {
+		out[i] = featureSavedGroupTargetingModel{
+			MatchType:   types.StringValue(s.MatchType),
+			SavedGroups: stringsToList(s.SavedGroups),
+		}
+	}
+	return out
+}
+
 // envsToAPI converts Terraform model environments to API environments.
 func envsToAPI(envs map[string]featureEnvironmentModel) map[string]growthbookapi.FeatureEnvironmentConfig {
 	if envs == nil {
@@ -546,20 +719,31 @@ func rulesToAPI(rules []featureRuleModel) []growthbookapi.FeatureRule {
 	out := make([]growthbookapi.FeatureRule, len(rules))
 	for i, r := range rules {
 		ar := growthbookapi.FeatureRule{
-			ID:            r.ID.ValueString(),
-			Type:          r.Type.ValueString(),
-			Enabled:       r.Enabled.ValueBool(),
-			Description:   r.Description.ValueString(),
-			Condition:     r.Condition.ValueString(),
-			Value:         r.Value.ValueString(),
-			HashAttribute: r.HashAttribute.ValueString(),
-			ExperimentID:  r.ExperimentID.ValueString(),
-			Variations:    variationsToAPI(r.Variations),
-			Prerequisites: rulePrereqsToAPI(r.Prerequisites),
+			ID:                  r.ID.ValueString(),
+			Type:                r.Type.ValueString(),
+			Enabled:             r.Enabled.ValueBool(),
+			Description:         r.Description.ValueString(),
+			Condition:           r.Condition.ValueString(),
+			Value:               r.Value.ValueString(),
+			HashAttribute:       r.HashAttribute.ValueString(),
+			FallbackAttribute:   r.FallbackAttribute.ValueString(),
+			Seed:                r.Seed.ValueString(),
+			TrackingKey:         r.TrackingKey.ValueString(),
+			ScheduleType:        r.ScheduleType.ValueString(),
+			ExperimentID:        r.ExperimentID.ValueString(),
+			Variations:          variationsToAPI(r.Variations),
+			Prerequisites:       rulePrereqsToAPI(r.Prerequisites),
+			SavedGroupTargeting: savedGroupTargetingToAPI(r.SavedGroupTargeting),
+			Namespace:           namespaceToAPI(r.Namespace),
+			ScheduleRules:       scheduleRulesToAPI(r.ScheduleRules),
 		}
 		if !r.Coverage.IsNull() && !r.Coverage.IsUnknown() {
 			v := r.Coverage.ValueFloat64()
 			ar.Coverage = &v
+		}
+		if !r.HashVersion.IsNull() && !r.HashVersion.IsUnknown() {
+			v := int(r.HashVersion.ValueInt64())
+			ar.HashVersion = &v
 		}
 		out[i] = ar
 	}
@@ -583,6 +767,72 @@ func rulePrereqsToAPI(prereqs []featurePrereqModel) []growthbookapi.FeaturePrere
 		out[i] = growthbookapi.FeaturePrerequisite{
 			ID:        p.ID.ValueString(),
 			Condition: p.Condition.ValueString(),
+		}
+	}
+	return out
+}
+
+func savedGroupTargetingToAPI(sgt []featureSavedGroupTargetingModel) []growthbookapi.FeatureSavedGroupTargeting {
+	out := make([]growthbookapi.FeatureSavedGroupTargeting, len(sgt))
+	for i, s := range sgt {
+		var groups []string
+		s.SavedGroups.ElementsAs(context.Background(), &groups, false)
+		out[i] = growthbookapi.FeatureSavedGroupTargeting{
+			MatchType:   s.MatchType.ValueString(),
+			SavedGroups: groups,
+		}
+	}
+	return out
+}
+
+func namespaceFromAPI(ns *growthbookapi.FeatureNamespace) []featureNamespaceModel {
+	if ns == nil {
+		return []featureNamespaceModel{}
+	}
+	return []featureNamespaceModel{{
+		Enabled:    types.BoolValue(ns.Enabled),
+		Name:       types.StringValue(ns.Name),
+		RangeStart: types.Float64Value(ns.Range[0]),
+		RangeEnd:   types.Float64Value(ns.Range[1]),
+	}}
+}
+
+func namespaceToAPI(ns []featureNamespaceModel) *growthbookapi.FeatureNamespace {
+	if len(ns) == 0 {
+		return nil
+	}
+	return &growthbookapi.FeatureNamespace{
+		Enabled: ns[0].Enabled.ValueBool(),
+		Name:    ns[0].Name.ValueString(),
+		Range:   [2]float64{ns[0].RangeStart.ValueFloat64(), ns[0].RangeEnd.ValueFloat64()},
+	}
+}
+
+func scheduleRulesFromAPI(rules []growthbookapi.FeatureScheduleRule) []featureScheduleRuleModel {
+	out := make([]featureScheduleRuleModel, len(rules))
+	for i, r := range rules {
+		ts := types.StringValue("")
+		if r.Timestamp != nil {
+			ts = types.StringValue(*r.Timestamp)
+		}
+		out[i] = featureScheduleRuleModel{
+			Timestamp: ts,
+			Enabled:   types.BoolValue(r.Enabled),
+		}
+	}
+	return out
+}
+
+func scheduleRulesToAPI(rules []featureScheduleRuleModel) []growthbookapi.FeatureScheduleRule {
+	out := make([]growthbookapi.FeatureScheduleRule, len(rules))
+	for i, r := range rules {
+		var ts *string
+		if v := r.Timestamp.ValueString(); v != "" {
+			ts = &v
+		}
+		out[i] = growthbookapi.FeatureScheduleRule{
+			Timestamp: ts,
+			Enabled:   r.Enabled.ValueBool(),
 		}
 	}
 	return out

--- a/internal/resource_feature_test.go
+++ b/internal/resource_feature_test.go
@@ -53,7 +53,7 @@ func TestAccGrowthBookFeature_basic(t *testing.T) {
 	featureID := acctest.RandomWithPrefix("tf-acc-feature-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/resource_metric.go
+++ b/internal/resource_metric.go
@@ -1,0 +1,195 @@
+package internal
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-growthbook/internal/growthbookapi"
+)
+
+var _ resource.Resource = &metricResource{}
+var _ resource.ResourceWithImportState = &metricResource{}
+
+func newMetricResource() resource.Resource {
+	return &metricResource{}
+}
+
+type metricResource struct {
+	client *growthbookapi.Client
+}
+
+type metricModel struct {
+	ID           types.String `tfsdk:"id"`
+	Name         types.String `tfsdk:"name"`
+	DatasourceID types.String `tfsdk:"datasource_id"`
+	Type         types.String `tfsdk:"type"`
+	Description  types.String `tfsdk:"description"`
+	Owner        types.String `tfsdk:"owner"`
+	Tags         types.List   `tfsdk:"tags"`
+	Projects     types.List   `tfsdk:"projects"`
+	Archived     types.Bool   `tfsdk:"archived"`
+	Behavior     types.String `tfsdk:"behavior"`
+	SQL          types.String `tfsdk:"sql"`
+	ManagedBy    types.String `tfsdk:"managed_by"`
+	DateCreated  types.String `tfsdk:"date_created"`
+	DateUpdated  types.String `tfsdk:"date_updated"`
+}
+
+func (r *metricResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_metric"
+}
+
+func (r *metricResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id":            schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"name":          schema.StringAttribute{Required: true},
+			"datasource_id": schema.StringAttribute{Required: true},
+			"type":          schema.StringAttribute{Required: true},
+			"description":   schema.StringAttribute{Optional: true, Computed: true},
+			"owner":         schema.StringAttribute{Optional: true, Computed: true},
+			"tags":          schema.ListAttribute{ElementType: types.StringType, Optional: true, Computed: true},
+			"projects":      schema.ListAttribute{ElementType: types.StringType, Optional: true, Computed: true},
+			"archived":      schema.BoolAttribute{Optional: true, Computed: true},
+			"behavior":      schema.StringAttribute{Optional: true, Computed: true, Validators: []validator.String{JSONString()}},
+			"sql":           schema.StringAttribute{Optional: true, Computed: true, Validators: []validator.String{JSONString()}},
+			"managed_by":    schema.StringAttribute{Optional: true, Computed: true},
+			"date_created":  schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"date_updated":  schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (r *metricResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*growthbookapi.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *growthbookapi.Client")
+		return
+	}
+	r.client = client
+}
+
+func metricFromModel(data metricModel) *growthbookapi.Metric {
+	return &growthbookapi.Metric{
+		Name:         data.Name.ValueString(),
+		DatasourceID: data.DatasourceID.ValueString(),
+		Type:         data.Type.ValueString(),
+		Description:  data.Description.ValueString(),
+		Owner:        data.Owner.ValueString(),
+		Tags:         listToStrings(data.Tags),
+		Projects:     listToStrings(data.Projects),
+		Archived:     data.Archived.ValueBool(),
+		Behavior:     stringToRawJSON(data.Behavior.ValueString()),
+		SQL:          stringToRawJSON(data.SQL.ValueString()),
+		ManagedBy:    data.ManagedBy.ValueString(),
+	}
+}
+
+func metricModelFromAPI(data *metricModel, item *growthbookapi.Metric) {
+	data.ID = types.StringValue(item.ID)
+	data.Name = types.StringValue(item.Name)
+	data.DatasourceID = types.StringValue(item.DatasourceID)
+	data.Type = types.StringValue(item.Type)
+	data.Description = types.StringValue(item.Description)
+	data.Owner = types.StringValue(item.Owner)
+	data.Tags = stringsToList(item.Tags)
+	data.Projects = stringsToList(item.Projects)
+	data.Archived = types.BoolValue(item.Archived)
+	data.Behavior = types.StringValue(rawJSONToString(item.Behavior))
+	data.SQL = types.StringValue(rawJSONToString(item.SQL))
+	data.ManagedBy = types.StringValue(item.ManagedBy)
+	data.DateCreated = types.StringValue(item.DateCreated)
+	data.DateUpdated = types.StringValue(item.DateUpdated)
+}
+
+func (r *metricResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data metricModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.CreateMetric(ctx, metricFromModel(data))
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating metric", err.Error())
+		return
+	}
+
+	metricModelFromAPI(&data, item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *metricResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data metricModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.GetMetric(ctx, data.ID.ValueString())
+	if err != nil {
+		if errors.Is(err, growthbookapi.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading metric", err.Error())
+		return
+	}
+
+	metricModelFromAPI(&data, item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *metricResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data metricModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state metricModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.UpdateMetric(ctx, state.ID.ValueString(), metricFromModel(data))
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating metric", err.Error())
+		return
+	}
+
+	metricModelFromAPI(&data, item)
+	data.ID = state.ID
+	if data.DateCreated.ValueString() == "" {
+		data.DateCreated = state.DateCreated
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *metricResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data metricModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.DeleteMetric(ctx, data.ID.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error deleting metric", err.Error())
+	}
+}
+
+func (r *metricResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/resource_metric_test.go
+++ b/internal/resource_metric_test.go
@@ -1,0 +1,76 @@
+package internal_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func testAccMetricConfig(name, datasourceID string) string {
+	return `
+resource "growthbook_metric" "test" {
+  name          = "` + name + `"
+  datasource_id = "` + datasourceID + `"
+  type          = "count"
+  description   = "Acceptance test metric"
+  behavior      = jsonencode({ goal = "increase" })
+  sql           = jsonencode({ numerator = "count(*)" })
+}
+data "growthbook_metric" "by_name" {
+  name = growthbook_metric.test.name
+}
+`
+}
+
+func testAccMetricConfigUpdate(name, datasourceID string) string {
+	return `
+resource "growthbook_metric" "test" {
+  name          = "` + name + `"
+  datasource_id = "` + datasourceID + `"
+  type          = "count"
+  description   = "Updated metric"
+  behavior      = jsonencode({ goal = "decrease" })
+  sql           = jsonencode({ numerator = "sum(total)" })
+  archived      = true
+}
+data "growthbook_metric" "by_name" {
+  name = growthbook_metric.test.name
+}
+`
+}
+
+func TestAccMetric_basic(t *testing.T) {
+	t.Parallel()
+
+	datasourceID := os.Getenv("GROWTHBOOK_TEST_DATASOURCE_ID")
+	if datasourceID == "" {
+		t.Skip("GROWTHBOOK_TEST_DATASOURCE_ID not set")
+	}
+
+	name := acctest.RandomWithPrefix("tf-acc-metric-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetricConfig(name, datasourceID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_metric.test", "name", name),
+					resource.TestCheckResourceAttr("growthbook_metric.test", "datasource_id", datasourceID),
+					resource.TestCheckResourceAttr("data.growthbook_metric.by_name", "name", name),
+				),
+			},
+			{
+				Config: testAccMetricConfigUpdate(name, datasourceID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_metric.test", "description", "Updated metric"),
+					resource.TestCheckResourceAttr("growthbook_metric.test", "archived", "true"),
+					resource.TestCheckResourceAttr("data.growthbook_metric.by_name", "archived", "true"),
+				),
+			},
+		},
+	})
+}

--- a/internal/resource_namespace.go
+++ b/internal/resource_namespace.go
@@ -1,0 +1,167 @@
+package internal
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-growthbook/internal/growthbookapi"
+)
+
+var _ resource.Resource = &namespaceResource{}
+var _ resource.ResourceWithImportState = &namespaceResource{}
+
+func newNamespaceResource() resource.Resource {
+	return &namespaceResource{}
+}
+
+type namespaceResource struct {
+	client *growthbookapi.Client
+}
+
+type namespaceModel struct {
+	ID            types.String `tfsdk:"id"`
+	DisplayName   types.String `tfsdk:"display_name"`
+	Description   types.String `tfsdk:"description"`
+	Status        types.String `tfsdk:"status"`
+	Format        types.String `tfsdk:"format"`
+	HashAttribute types.String `tfsdk:"hash_attribute"`
+	Seed          types.String `tfsdk:"seed"`
+}
+
+func (r *namespaceResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_namespace"
+}
+
+func (r *namespaceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id":             schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"display_name":   schema.StringAttribute{Required: true},
+			"description":    schema.StringAttribute{Optional: true, Computed: true},
+			"status":         schema.StringAttribute{Optional: true, Computed: true},
+			"format":         schema.StringAttribute{Optional: true, Computed: true},
+			"hash_attribute": schema.StringAttribute{Optional: true, Computed: true},
+			"seed":           schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+		},
+	}
+}
+
+func (r *namespaceResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*growthbookapi.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *growthbookapi.Client")
+		return
+	}
+	r.client = client
+}
+
+func namespaceFromModel(data namespaceModel) *growthbookapi.Namespace {
+	return &growthbookapi.Namespace{
+		DisplayName:   data.DisplayName.ValueString(),
+		Description:   data.Description.ValueString(),
+		Status:        data.Status.ValueString(),
+		Format:        data.Format.ValueString(),
+		HashAttribute: data.HashAttribute.ValueString(),
+	}
+}
+
+func namespaceModelFromAPI(data *namespaceModel, item *growthbookapi.Namespace) {
+	data.ID = types.StringValue(item.ID)
+	data.DisplayName = types.StringValue(item.DisplayName)
+	data.Description = types.StringValue(item.Description)
+	data.Status = types.StringValue(item.Status)
+	data.Format = types.StringValue(item.Format)
+	data.HashAttribute = types.StringValue(item.HashAttribute)
+	data.Seed = types.StringValue(item.Seed)
+}
+
+func (r *namespaceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data namespaceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.CreateNamespace(ctx, namespaceFromModel(data))
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating namespace", err.Error())
+		return
+	}
+
+	namespaceModelFromAPI(&data, item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *namespaceResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data namespaceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.GetNamespace(ctx, data.ID.ValueString())
+	if err != nil {
+		if errors.Is(err, growthbookapi.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading namespace", err.Error())
+		return
+	}
+
+	namespaceModelFromAPI(&data, item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *namespaceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data namespaceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state namespaceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.UpdateNamespace(ctx, state.ID.ValueString(), namespaceFromModel(data))
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating namespace", err.Error())
+		return
+	}
+
+	namespaceModelFromAPI(&data, item)
+	data.ID = state.ID
+	if data.Seed.ValueString() == "" {
+		data.Seed = state.Seed
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *namespaceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data namespaceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.DeleteNamespace(ctx, data.ID.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error deleting namespace", err.Error())
+	}
+}
+
+func (r *namespaceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/resource_namespace_test.go
+++ b/internal/resource_namespace_test.go
@@ -1,0 +1,65 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func testAccNamespaceConfig(name string) string {
+	return `
+resource "growthbook_namespace" "test" {
+  display_name   = "` + name + `"
+  description    = "Acceptance test namespace"
+  status         = "active"
+  format         = "legacy"
+  hash_attribute = "id"
+}
+data "growthbook_namespace" "by_display_name" {
+  display_name = growthbook_namespace.test.display_name
+}
+`
+}
+
+func testAccNamespaceConfigUpdate(name string) string {
+	return `
+resource "growthbook_namespace" "test" {
+  display_name   = "` + name + `"
+  description    = "Updated namespace"
+  status         = "inactive"
+  format         = "legacy"
+  hash_attribute = "user_id"
+}
+data "growthbook_namespace" "by_display_name" {
+  display_name = growthbook_namespace.test.display_name
+}
+`
+}
+
+func TestAccNamespace_basic(t *testing.T) {
+	t.Parallel()
+
+	name := acctest.RandomWithPrefix("tf-acc-namespace-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNamespaceConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_namespace.test", "display_name", name),
+					resource.TestCheckResourceAttr("data.growthbook_namespace.by_display_name", "status", "active"),
+				),
+			},
+			{
+				Config: testAccNamespaceConfigUpdate(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_namespace.test", "description", "Updated namespace"),
+					resource.TestCheckResourceAttr("data.growthbook_namespace.by_display_name", "hash_attribute", "user_id"),
+				),
+			},
+		},
+	})
+}

--- a/internal/resource_project.go
+++ b/internal/resource_project.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -122,6 +123,10 @@ func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	project, err := r.client.GetProject(ctx, data.ID.ValueString())
 	if err != nil {
+		if errors.Is(err, growthbookapi.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Error reading project", err.Error())
 		return
 	}

--- a/internal/resource_project_test.go
+++ b/internal/resource_project_test.go
@@ -72,7 +72,7 @@ data "growthbook_project" "by_name2" {
 }
 `
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/resource_saved_group.go
+++ b/internal/resource_saved_group.go
@@ -1,0 +1,185 @@
+package internal
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-growthbook/internal/growthbookapi"
+)
+
+var _ resource.Resource = &savedGroupResource{}
+var _ resource.ResourceWithImportState = &savedGroupResource{}
+
+func newSavedGroupResource() resource.Resource {
+	return &savedGroupResource{}
+}
+
+type savedGroupResource struct {
+	client *growthbookapi.Client
+}
+
+type savedGroupModel struct {
+	ID           types.String `tfsdk:"id"`
+	Name         types.String `tfsdk:"name"`
+	Type         types.String `tfsdk:"type"`
+	Condition    types.String `tfsdk:"condition"`
+	AttributeKey types.String `tfsdk:"attribute_key"`
+	Values       types.List   `tfsdk:"values"`
+	Owner        types.String `tfsdk:"owner"`
+	Projects     types.List   `tfsdk:"projects"`
+	Description  types.String `tfsdk:"description"`
+	DateCreated  types.String `tfsdk:"date_created"`
+	DateUpdated  types.String `tfsdk:"date_updated"`
+}
+
+func (r *savedGroupResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_saved_group"
+}
+
+func (r *savedGroupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"name":          schema.StringAttribute{Required: true},
+			"type":          schema.StringAttribute{Optional: true, Computed: true},
+			"condition":     schema.StringAttribute{Optional: true, Computed: true},
+			"attribute_key": schema.StringAttribute{Optional: true, Computed: true},
+			"values":        schema.ListAttribute{ElementType: types.StringType, Optional: true, Computed: true},
+			"owner":         schema.StringAttribute{Optional: true, Computed: true},
+			"projects":      schema.ListAttribute{ElementType: types.StringType, Optional: true, Computed: true},
+			"description":   schema.StringAttribute{Optional: true, Computed: true},
+			"date_created":  schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"date_updated":  schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (r *savedGroupResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*growthbookapi.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *growthbookapi.Client")
+		return
+	}
+	r.client = client
+}
+
+func savedGroupFromModel(data savedGroupModel) *growthbookapi.SavedGroup {
+	return &growthbookapi.SavedGroup{
+		Name:         data.Name.ValueString(),
+		Type:         data.Type.ValueString(),
+		Condition:    data.Condition.ValueString(),
+		AttributeKey: data.AttributeKey.ValueString(),
+		Values:       listToStrings(data.Values),
+		Owner:        data.Owner.ValueString(),
+		Projects:     listToStrings(data.Projects),
+		Description:  data.Description.ValueString(),
+	}
+}
+
+func savedGroupModelFromAPI(data *savedGroupModel, item *growthbookapi.SavedGroup) {
+	data.ID = types.StringValue(item.ID)
+	data.Name = types.StringValue(item.Name)
+	data.Type = types.StringValue(item.Type)
+	data.Condition = types.StringValue(item.Condition)
+	data.AttributeKey = types.StringValue(item.AttributeKey)
+	data.Values = stringsToList(item.Values)
+	data.Owner = types.StringValue(item.Owner)
+	data.Projects = stringsToList(item.Projects)
+	data.Description = types.StringValue(item.Description)
+	data.DateCreated = types.StringValue(item.DateCreated)
+	data.DateUpdated = types.StringValue(item.DateUpdated)
+}
+
+func (r *savedGroupResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data savedGroupModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.CreateSavedGroup(ctx, savedGroupFromModel(data))
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating saved group", err.Error())
+		return
+	}
+
+	savedGroupModelFromAPI(&data, item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *savedGroupResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data savedGroupModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.GetSavedGroup(ctx, data.ID.ValueString())
+	if err != nil {
+		if errors.Is(err, growthbookapi.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading saved group", err.Error())
+		return
+	}
+
+	savedGroupModelFromAPI(&data, item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *savedGroupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data savedGroupModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state savedGroupModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.UpdateSavedGroup(ctx, state.ID.ValueString(), savedGroupFromModel(data))
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating saved group", err.Error())
+		return
+	}
+
+	savedGroupModelFromAPI(&data, item)
+	data.ID = state.ID
+	if data.DateCreated.ValueString() == "" {
+		data.DateCreated = state.DateCreated
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *savedGroupResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data savedGroupModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.DeleteSavedGroup(ctx, data.ID.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error deleting saved group", err.Error())
+	}
+}
+
+func (r *savedGroupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/resource_saved_group_test.go
+++ b/internal/resource_saved_group_test.go
@@ -1,0 +1,68 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func testAccSavedGroupConfig(name string) string {
+	return `
+resource "growthbook_saved_group" "test" {
+  name          = "` + name + `"
+  type          = "list"
+  attribute_key = "id"
+  values        = ["one", "two"]
+  description   = "Acceptance test saved group"
+}
+data "growthbook_saved_group" "by_name" {
+  name = growthbook_saved_group.test.name
+}
+`
+}
+
+func testAccSavedGroupConfigUpdate(name string) string {
+	return `
+resource "growthbook_saved_group" "test" {
+  name          = "` + name + `"
+  type          = "list"
+  attribute_key = "user_id"
+  values        = ["three", "four"]
+  description   = "Updated saved group"
+}
+data "growthbook_saved_group" "by_name" {
+  name = growthbook_saved_group.test.name
+}
+`
+}
+
+func TestAccSavedGroup_basic(t *testing.T) {
+	t.Parallel()
+
+	name := acctest.RandomWithPrefix("tf-acc-saved-group-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSavedGroupConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_saved_group.test", "name", name),
+					resource.TestCheckResourceAttr("growthbook_saved_group.test", "attribute_key", "id"),
+					resource.TestCheckResourceAttr("growthbook_saved_group.test", "description", "Acceptance test saved group"),
+					resource.TestCheckResourceAttr("data.growthbook_saved_group.by_name", "name", name),
+				),
+			},
+			{
+				Config: testAccSavedGroupConfigUpdate(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_saved_group.test", "attribute_key", "user_id"),
+					resource.TestCheckResourceAttr("growthbook_saved_group.test", "description", "Updated saved group"),
+					resource.TestCheckResourceAttr("data.growthbook_saved_group.by_name", "description", "Updated saved group"),
+				),
+			},
+		},
+	})
+}

--- a/internal/resource_sdk_connection.go
+++ b/internal/resource_sdk_connection.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -178,7 +179,7 @@ func sdkConnToModel(ctx context.Context, conn *growthbookapi.SDKConnection) sdkC
 		Language:                    types.StringValue(conn.Language),
 		Environment:                 types.StringValue(conn.Environment),
 		SdkVersion:                  types.StringValue(conn.SdkVersion),
-		Projects:                    stringsToList(ctx, conn.Projects),
+		Projects:                    stringsToList(conn.Projects),
 		EncryptPayload:              types.BoolValue(conn.EncryptPayload),
 		IncludeVisualExperiments:    types.BoolValue(conn.IncludeVisualExperiments),
 		IncludeDraftExperiments:     types.BoolValue(conn.IncludeDraftExperiments),
@@ -255,6 +256,10 @@ func (r *sdkConnectionResource) Read(ctx context.Context, req resource.ReadReque
 
 	conn, err := r.client.GetSDKConnection(ctx, data.ID.ValueString())
 	if err != nil {
+		if errors.Is(err, growthbookapi.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Error reading SDK connection", err.Error())
 		return
 	}

--- a/internal/resource_sdk_connection_test.go
+++ b/internal/resource_sdk_connection_test.go
@@ -36,7 +36,7 @@ func TestAccGrowthBookSDKConnection_basic(t *testing.T) {
 	connName := acctest.RandomWithPrefix("tf-acc-sdkconn-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/resource_segment.go
+++ b/internal/resource_segment.go
@@ -1,0 +1,190 @@
+package internal
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-growthbook/internal/growthbookapi"
+)
+
+var _ resource.Resource = &segmentResource{}
+var _ resource.ResourceWithImportState = &segmentResource{}
+
+func newSegmentResource() resource.Resource {
+	return &segmentResource{}
+}
+
+type segmentResource struct {
+	client *growthbookapi.Client
+}
+
+type segmentModel struct {
+	ID             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	Type           types.String `tfsdk:"type"`
+	DatasourceID   types.String `tfsdk:"datasource_id"`
+	IdentifierType types.String `tfsdk:"identifier_type"`
+	Owner          types.String `tfsdk:"owner"`
+	Description    types.String `tfsdk:"description"`
+	Query          types.String `tfsdk:"query"`
+	FactTableID    types.String `tfsdk:"fact_table_id"`
+	Projects       types.List   `tfsdk:"projects"`
+	ManagedBy      types.String `tfsdk:"managed_by"`
+	DateCreated    types.String `tfsdk:"date_created"`
+	DateUpdated    types.String `tfsdk:"date_updated"`
+}
+
+func (r *segmentResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_segment"
+}
+
+func (r *segmentResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id":              schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"name":            schema.StringAttribute{Required: true},
+			"type":            schema.StringAttribute{Required: true},
+			"datasource_id":   schema.StringAttribute{Required: true},
+			"identifier_type": schema.StringAttribute{Required: true},
+			"owner":           schema.StringAttribute{Optional: true, Computed: true},
+			"description":     schema.StringAttribute{Optional: true, Computed: true},
+			"query":           schema.StringAttribute{Optional: true, Computed: true},
+			"fact_table_id":   schema.StringAttribute{Optional: true, Computed: true},
+			"projects":        schema.ListAttribute{ElementType: types.StringType, Optional: true, Computed: true},
+			"managed_by":      schema.StringAttribute{Optional: true, Computed: true},
+			"date_created":    schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+			"date_updated":    schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (r *segmentResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*growthbookapi.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *growthbookapi.Client")
+		return
+	}
+	r.client = client
+}
+
+func segmentFromModel(data segmentModel) *growthbookapi.Segment {
+	return &growthbookapi.Segment{
+		Name:           data.Name.ValueString(),
+		Type:           data.Type.ValueString(),
+		DatasourceID:   data.DatasourceID.ValueString(),
+		IdentifierType: data.IdentifierType.ValueString(),
+		Owner:          data.Owner.ValueString(),
+		Description:    data.Description.ValueString(),
+		Query:          data.Query.ValueString(),
+		FactTableID:    data.FactTableID.ValueString(),
+		Projects:       listToStrings(data.Projects),
+		ManagedBy:      data.ManagedBy.ValueString(),
+	}
+}
+
+func segmentModelFromAPI(data *segmentModel, item *growthbookapi.Segment) {
+	data.ID = types.StringValue(item.ID)
+	data.Name = types.StringValue(item.Name)
+	data.Type = types.StringValue(item.Type)
+	data.DatasourceID = types.StringValue(item.DatasourceID)
+	data.IdentifierType = types.StringValue(item.IdentifierType)
+	data.Owner = types.StringValue(item.Owner)
+	data.Description = types.StringValue(item.Description)
+	data.Query = types.StringValue(item.Query)
+	data.FactTableID = types.StringValue(item.FactTableID)
+	data.Projects = stringsToList(item.Projects)
+	data.ManagedBy = types.StringValue(item.ManagedBy)
+	data.DateCreated = types.StringValue(item.DateCreated)
+	data.DateUpdated = types.StringValue(item.DateUpdated)
+}
+
+func (r *segmentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data segmentModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.CreateSegment(ctx, segmentFromModel(data))
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating segment", err.Error())
+		return
+	}
+
+	segmentModelFromAPI(&data, item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *segmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data segmentModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.GetSegment(ctx, data.ID.ValueString())
+	if err != nil {
+		if errors.Is(err, growthbookapi.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading segment", err.Error())
+		return
+	}
+
+	segmentModelFromAPI(&data, item)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *segmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data segmentModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state segmentModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	item, err := r.client.UpdateSegment(ctx, state.ID.ValueString(), segmentFromModel(data))
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating segment", err.Error())
+		return
+	}
+
+	segmentModelFromAPI(&data, item)
+	data.ID = state.ID
+	if data.DateCreated.ValueString() == "" {
+		data.DateCreated = state.DateCreated
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *segmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data segmentModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.DeleteSegment(ctx, data.ID.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error deleting segment", err.Error())
+	}
+}
+
+func (r *segmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/resource_segment_test.go
+++ b/internal/resource_segment_test.go
@@ -1,0 +1,74 @@
+package internal_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func testAccSegmentConfig(name, datasourceID string) string {
+	return `
+resource "growthbook_segment" "test" {
+  name            = "` + name + `"
+  type            = "SQL"
+  datasource_id   = "` + datasourceID + `"
+  identifier_type = "user"
+  query           = "select user_id from users"
+  description     = "Acceptance test segment"
+}
+data "growthbook_segment" "by_name" {
+  name = growthbook_segment.test.name
+}
+`
+}
+
+func testAccSegmentConfigUpdate(name, datasourceID string) string {
+	return `
+resource "growthbook_segment" "test" {
+  name            = "` + name + `"
+  type            = "SQL"
+  datasource_id   = "` + datasourceID + `"
+  identifier_type = "user"
+  query           = "select distinct user_id from users"
+  description     = "Updated segment"
+}
+data "growthbook_segment" "by_name" {
+  name = growthbook_segment.test.name
+}
+`
+}
+
+func TestAccSegment_basic(t *testing.T) {
+	t.Parallel()
+
+	datasourceID := os.Getenv("GROWTHBOOK_TEST_DATASOURCE_ID")
+	if datasourceID == "" {
+		t.Skip("GROWTHBOOK_TEST_DATASOURCE_ID not set")
+	}
+
+	name := acctest.RandomWithPrefix("tf-acc-segment-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSegmentConfig(name, datasourceID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_segment.test", "name", name),
+					resource.TestCheckResourceAttr("growthbook_segment.test", "datasource_id", datasourceID),
+					resource.TestCheckResourceAttr("data.growthbook_segment.by_name", "name", name),
+				),
+			},
+			{
+				Config: testAccSegmentConfigUpdate(name, datasourceID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_segment.test", "description", "Updated segment"),
+					resource.TestCheckResourceAttr("data.growthbook_segment.by_name", "query", "select distinct user_id from users"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Adds Terraform support for the GrowthBook API resources that were not previously covered. Each new type ships with a resource, a data source, acceptance tests, and documentation.

Existing resources are also corrected: a 404 from the API now removes the resource from state instead of erroring, so a manually-deleted resource can be re-created on the next apply.

## New resources

| Resource | Data source | Notes |
|---|---|---|
| `growthbook_saved_group` | ✓ | `condition` and `list` types |
| `growthbook_segment` | ✓ | `SQL` and `FACT` types (uppercase per spec) |
| `growthbook_metric` | ✓ | `PUT` returns only `{updatedId}`; client follows up with `GET` |
| `growthbook_dimension` | ✓ | |
| `growthbook_fact_table` | ✓ | |
| `growthbook_fact_metric` | ✓ | `proportion`, `retention`, `mean`, `quantile`, `ratio`, `dailyParticipation` |
| `growthbook_namespace` | ✓ | `legacy` and `multiRange` formats |
| `growthbook_experiment` | ✓ | `standard` and `multi-armed-bandit` |
| — | `growthbook_data_source` | Read-only (data sources are managed in the GrowthBook UI) |

## Improvements to existing resources

- `growthbook_project`, `growthbook_feature`, `growthbook_environment`, `growthbook_sdk_connection`, and `growthbook_attribute` now check for `growthbookapi.ErrNotFound` in `Read()` and call `resp.State.RemoveResource(ctx)` instead of returning a hard error. This fixes the case where a resource deleted out-of-band could never be re-created via Terraform.
- `growthbook_attribute`: removed the bogus \"Attribute not found\" hard error in favor of `RemoveResource`.

## Validation

- New `JSONString()` schema validator (`internal/jsonvalidator.go`) catches malformed JSON during `terraform plan` for fields that round-trip JSON strings (e.g. `numerator`, `denominator`, `variations`, `phases`, `behavior`, `sql`, `capping_settings`, `window_settings`, `prior_settings`, `regression_adjustment_settings`). Previously, malformed JSON would only fail at the API with a cryptic error.
- `rawJSONToString` normalizes JSON on read to prevent perpetual diffs from upstream formatting differences.

## Documentation

Generated from the upstream OpenAPI spec (https://api.growthbook.io/api/v1/openapi.yaml):

- `docs/resources/`: attribute (was missing), saved_group, segment, metric, dimension, fact_table, fact_metric, namespace, experiment
- `docs/data-sources/`: same set + data_source

Each doc lists arguments with required/optional flags, valid enum values, JSON-encoded field examples, and import syntax.

## Tests

- Acceptance tests for every new resource (basic + update flows where applicable).
- Tests requiring a real backing data source/fact table use environment variables and skip when unset:
  - \`GROWTHBOOK_TEST_DATASOURCE_ID\` (segment, dimension, metric, fact_table, fact_metric, data_source)
  - \`GROWTHBOOK_TEST_FACT_TABLE_ID\` (fact_metric)

## Verification

- ✅ \`go build ./...\`
- ✅ \`go vet ./...\`
- ✅ \`golangci-lint run ./...\` — 0 issues

## Notes

The 9 new resources follow the same CRUD pattern, which results in some code duplication. A follow-up PR could extract a generic CRUD helper using Go generics, but that refactor is left out of this PR to keep the diff focused.