### PR TITLE
fix: apply saved_group_references_enabled via PUT after SDK connection create

### DIFF
--- a/internal/growthbookapi/sdk_connection.go
+++ b/internal/growthbookapi/sdk_connection.go
@@ -7,6 +7,11 @@ import (
 )
 
 // CreateSDKConnection creates a new SDK connection in GrowthBook.
+//
+// The GrowthBook API does not honour savedGroupReferencesEnabled on the POST
+// request — it always returns false.  If the requested value is true we issue
+// an immediate PUT to apply it before returning, so callers always receive a
+// result that matches what they asked for.
 func (c *Client) CreateSDKConnection(ctx context.Context, s *SDKConnection) (*SDKConnection, error) {
 	out, err := fetcher[SDKConnection](c, "POST", "/sdk-connections").One(ctx, s, "sdkConnection")
 	if err != nil {
@@ -14,6 +19,13 @@ func (c *Client) CreateSDKConnection(ctx context.Context, s *SDKConnection) (*SD
 	}
 	if len(out.Languages) != 0 {
 		out.Language = out.Languages[0]
+	}
+	if out.SavedGroupReferencesEnabled != s.SavedGroupReferencesEnabled {
+		updated, err := c.UpdateSDKConnection(ctx, out.ID, s)
+		if err != nil {
+			return nil, err
+		}
+		return updated, nil
 	}
 	return &out, nil
 }

--- a/internal/resource_experiment_test.go
+++ b/internal/resource_experiment_test.go
@@ -1,0 +1,72 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func testAccExperimentConfig(name string) string {
+	return `
+resource "growthbook_experiment" "test" {
+  name         = "` + name + `"
+  tracking_key = "` + name + `-tracking"
+  description  = "Acceptance test experiment"
+  variations   = jsonencode([
+    { key = "0", name = "Control" },
+    { key = "1", name = "Variant" }
+  ])
+}
+data "growthbook_experiment" "by_name" {
+  name = growthbook_experiment.test.name
+}
+`
+}
+
+func testAccExperimentConfigUpdate(name string) string {
+	return `
+resource "growthbook_experiment" "test" {
+  name         = "` + name + `"
+  tracking_key = "` + name + `-tracking"
+  description  = "Updated experiment"
+  hypothesis   = "Variant increases conversions"
+  variations   = jsonencode([
+    { key = "0", name = "Control" },
+    { key = "1", name = "Variant" }
+  ])
+  phases = jsonencode([{ name = "Phase 1" }])
+}
+data "growthbook_experiment" "by_name" {
+  name = growthbook_experiment.test.name
+}
+`
+}
+
+func TestAccExperiment_basic(t *testing.T) {
+	t.Parallel()
+
+	name := acctest.RandomWithPrefix("tf-acc-experiment-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExperimentConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_experiment.test", "name", name),
+					resource.TestCheckResourceAttr("data.growthbook_experiment.by_name", "tracking_key", name+"-tracking"),
+				),
+			},
+			{
+				Config: testAccExperimentConfigUpdate(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_experiment.test", "description", "Updated experiment"),
+					resource.TestCheckResourceAttr(
+						"data.growthbook_experiment.by_name", "hypothesis", "Variant increases conversions"),
+				),
+			},
+		},
+	})
+}

--- a/internal/resource_fact_metric_test.go
+++ b/internal/resource_fact_metric_test.go
@@ -1,0 +1,80 @@
+package internal_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func testAccFactMetricConfig(name, datasourceID, factTableID string) string {
+	return `
+resource "growthbook_fact_metric" "test" {
+  name        = "` + name + `"
+  metric_type = "proportion"
+  datasource  = "` + datasourceID + `"
+  numerator   = jsonencode({ factTableId = "` + factTableID + `", column = "" })
+  description = "Acceptance test fact metric"
+}
+data "growthbook_fact_metric" "by_name" {
+  name = growthbook_fact_metric.test.name
+}
+`
+}
+
+func testAccFactMetricConfigUpdate(name, datasourceID, factTableID string) string {
+	return `
+resource "growthbook_fact_metric" "test" {
+  name        = "` + name + `"
+  metric_type = "proportion"
+  datasource  = "` + datasourceID + `"
+  numerator   = jsonencode({ factTableId = "` + factTableID + `", column = "" })
+  denominator = jsonencode({ factTableId = "` + factTableID + `", column = "$$distinctUsers" })
+  inverse     = true
+  description = "Updated fact metric"
+}
+data "growthbook_fact_metric" "by_name" {
+  name = growthbook_fact_metric.test.name
+}
+`
+}
+
+func TestAccFactMetric_basic(t *testing.T) {
+	t.Parallel()
+
+	datasourceID := os.Getenv("GROWTHBOOK_TEST_DATASOURCE_ID")
+	if datasourceID == "" {
+		t.Skip("GROWTHBOOK_TEST_DATASOURCE_ID not set")
+	}
+
+	factTableID := os.Getenv("GROWTHBOOK_TEST_FACT_TABLE_ID")
+	if factTableID == "" {
+		t.Skip("GROWTHBOOK_TEST_FACT_TABLE_ID not set")
+	}
+
+	name := acctest.RandomWithPrefix("tf-acc-fact-metric-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFactMetricConfig(name, datasourceID, factTableID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_fact_metric.test", "name", name),
+					resource.TestCheckResourceAttr("growthbook_fact_metric.test", "metric_type", "proportion"),
+					resource.TestCheckResourceAttr(
+						"data.growthbook_fact_metric.by_name", "description", "Acceptance test fact metric"),
+				),
+			},
+			{
+				Config: testAccFactMetricConfigUpdate(name, datasourceID, factTableID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_fact_metric.test", "inverse", "true"),
+					resource.TestCheckResourceAttr("data.growthbook_fact_metric.by_name", "description", "Updated fact metric"),
+				),
+			},
+		},
+	})
+}

--- a/internal/resource_namespace_test.go
+++ b/internal/resource_namespace_test.go
@@ -1,0 +1,65 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func testAccNamespaceConfig(name string) string {
+	return `
+resource "growthbook_namespace" "test" {
+  display_name   = "` + name + `"
+  description    = "Acceptance test namespace"
+  status         = "active"
+  format         = "legacy"
+  hash_attribute = "id"
+}
+data "growthbook_namespace" "by_display_name" {
+  display_name = growthbook_namespace.test.display_name
+}
+`
+}
+
+func testAccNamespaceConfigUpdate(name string) string {
+	return `
+resource "growthbook_namespace" "test" {
+  display_name   = "` + name + `"
+  description    = "Updated namespace"
+  status         = "inactive"
+  format         = "legacy"
+  hash_attribute = "user_id"
+}
+data "growthbook_namespace" "by_display_name" {
+  display_name = growthbook_namespace.test.display_name
+}
+`
+}
+
+func TestAccNamespace_basic(t *testing.T) {
+	t.Parallel()
+
+	name := acctest.RandomWithPrefix("tf-acc-namespace-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNamespaceConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_namespace.test", "display_name", name),
+					resource.TestCheckResourceAttr("data.growthbook_namespace.by_display_name", "status", "active"),
+				),
+			},
+			{
+				Config: testAccNamespaceConfigUpdate(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_namespace.test", "description", "Updated namespace"),
+					resource.TestCheckResourceAttr("data.growthbook_namespace.by_display_name", "hash_attribute", "user_id"),
+				),
+			},
+		},
+	})
+}

--- a/internal/resource_sdk_connection_test.go
+++ b/internal/resource_sdk_connection_test.go
@@ -30,13 +30,32 @@ data "growthbook_sdk_connection" "hh" {
 `
 }
 
+func testAccSDKConnectionSavedGroupConfig(name string) string {
+	return `
+resource "growthbook_project" "test" {
+  name = "` + name + `-proj"
+}
+resource "growthbook_environment" "test" {
+  name        = "` + name + `-env"
+  projects    = [growthbook_project.test.id]
+}
+resource "growthbook_sdk_connection" "test" {
+  name                           = "` + name + `"
+  language                       = "ios"
+  environment                    = growthbook_environment.test.id
+  projects                       = [growthbook_project.test.id]
+  saved_group_references_enabled = true
+}
+`
+}
+
 func TestAccGrowthBookSDKConnection_basic(t *testing.T) {
 	t.Parallel()
 
 	connName := acctest.RandomWithPrefix("tf-acc-sdkconn-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -76,6 +95,30 @@ func TestAccGrowthBookSDKConnection_basic(t *testing.T) {
 						}
 						return nil
 					}),
+				),
+			},
+		},
+	})
+}
+
+// TestAccGrowthBookSDKConnection_savedGroupReferences verifies that
+// saved_group_references_enabled=true is persisted correctly after create.
+// The GrowthBook API ignores this field on POST and always returns false;
+// the provider must issue a follow-up PUT to apply it.
+func TestAccGrowthBookSDKConnection_savedGroupReferences(t *testing.T) {
+	t.Parallel()
+
+	connName := acctest.RandomWithPrefix("tf-acc-sdkconn-sg-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSDKConnectionSavedGroupConfig(connName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_sdk_connection.test", "name", connName),
+					resource.TestCheckResourceAttr("growthbook_sdk_connection.test", "saved_group_references_enabled", "true"),
 				),
 			},
 		},

--- a/internal/resource_segment_test.go
+++ b/internal/resource_segment_test.go
@@ -1,0 +1,74 @@
+package internal_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func testAccSegmentConfig(name, datasourceID string) string {
+	return `
+resource "growthbook_segment" "test" {
+  name            = "` + name + `"
+  type            = "SQL"
+  datasource_id   = "` + datasourceID + `"
+  identifier_type = "user"
+  query           = "select user_id from users"
+  description     = "Acceptance test segment"
+}
+data "growthbook_segment" "by_name" {
+  name = growthbook_segment.test.name
+}
+`
+}
+
+func testAccSegmentConfigUpdate(name, datasourceID string) string {
+	return `
+resource "growthbook_segment" "test" {
+  name            = "` + name + `"
+  type            = "SQL"
+  datasource_id   = "` + datasourceID + `"
+  identifier_type = "user"
+  query           = "select distinct user_id from users"
+  description     = "Updated segment"
+}
+data "growthbook_segment" "by_name" {
+  name = growthbook_segment.test.name
+}
+`
+}
+
+func TestAccSegment_basic(t *testing.T) {
+	t.Parallel()
+
+	datasourceID := os.Getenv("GROWTHBOOK_TEST_DATASOURCE_ID")
+	if datasourceID == "" {
+		t.Skip("GROWTHBOOK_TEST_DATASOURCE_ID not set")
+	}
+
+	name := acctest.RandomWithPrefix("tf-acc-segment-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSegmentConfig(name, datasourceID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_segment.test", "name", name),
+					resource.TestCheckResourceAttr("growthbook_segment.test", "datasource_id", datasourceID),
+					resource.TestCheckResourceAttr("data.growthbook_segment.by_name", "name", name),
+				),
+			},
+			{
+				Config: testAccSegmentConfigUpdate(name, datasourceID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("growthbook_segment.test", "description", "Updated segment"),
+					resource.TestCheckResourceAttr("data.growthbook_segment.by_name", "query", "select distinct user_id from users"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Problem

The GrowthBook API ignores `savedGroupReferencesEnabled` on the `POST /sdk-connections` endpoint — it always returns `false` in the response regardless of what was sent. When Terraform creates an SDK connection with `saved_group_references_enabled = true`, the provider stores the API's `false` response in state. Terraform then detects the mismatch and emits:

```
Error: Provider produced inconsistent result after apply
.saved_group_references_enabled: was cty.True, but now cty.False.
```

This taints the resource, causing an unnecessary destroy+recreate on every subsequent plan.

## Fix

In `CreateSDKConnection`, after the `POST` succeeds, check whether the returned `SavedGroupReferencesEnabled` matches what was requested. If not, immediately issue a `PUT` to apply the correct value before returning to the caller.

## Test

Added `TestAccGrowthBookSDKConnection_savedGroupReferences` to reproduce the scenario and verify the fix.